### PR TITLE
Improve login reliability

### DIFF
--- a/MainCore/Commands/Features/LoginCommand.cs
+++ b/MainCore/Commands/Features/LoginCommand.cs
@@ -16,6 +16,14 @@ namespace MainCore.Commands.Features
             var html = browser.Html;
             if (LoginParser.IsIngamePage(html)) return Result.Ok();
 
+            Result result;
+            result = await browser.WaitElement(By.Name("name"), cancellationToken);
+            if (result.IsFailed) return result;
+            result = await browser.WaitElement(By.Name("password"), cancellationToken);
+            if (result.IsFailed) return result;
+            result = await browser.WaitElement(By.CssSelector("#loginScene button.green"), cancellationToken);
+            if (result.IsFailed) return result;
+
             var buttonNode = LoginParser.GetLoginButton(html);
             if (buttonNode is null) return Retry.ButtonNotFound("login");
             var usernameNode = LoginParser.GetUsernameInput(html);
@@ -25,7 +33,6 @@ namespace MainCore.Commands.Features
 
             var (username, password) = GetLoginInfo(command.AccountId, context);
 
-            Result result;
             result = await browser.Input(By.XPath(usernameNode.XPath), username);
             if (result.IsFailed) return result;
             result = await browser.Input(By.XPath(passwordNode.XPath), password);

--- a/MainCore/Services/ChromeBrowser.cs
+++ b/MainCore/Services/ChromeBrowser.cs
@@ -195,6 +195,17 @@ namespace MainCore.Services
             return Wait(driver => PageChanged(driver, part) && customCondition(driver), cancellationToken);
         }
 
+        public Task<Result> WaitElement(By by, CancellationToken cancellationToken)
+        {
+            return Wait(driver =>
+            {
+                var elements = driver.FindElements(by);
+                if (elements.Count == 0) return false;
+                var element = elements[0];
+                return element.Displayed && element.Enabled;
+            }, cancellationToken);
+        }
+
         public async Task Close()
         {
             await Task.Run(() => _driver?.Quit());

--- a/MainCore/Services/IChromeBrowser.cs
+++ b/MainCore/Services/IChromeBrowser.cs
@@ -34,5 +34,7 @@ namespace MainCore.Services
         Task<Result> WaitPageChanged(string part, Predicate<IWebDriver> customCondition, CancellationToken cancellationToken);
 
         Task<Result> WaitPageLoaded(CancellationToken cancellationToken);
+
+        Task<Result> WaitElement(By by, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- add `WaitElement` helper to Chrome browser
- ensure login inputs are ready before attempting to log in

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4a9b0c9c832fb36a1b0b4c274170