### PR TITLE
Add Telegram settings entity and support

### DIFF
--- a/MainCore/Commands/UI/Misc/SaveTelegramSettingCommand.cs
+++ b/MainCore/Commands/UI/Misc/SaveTelegramSettingCommand.cs
@@ -1,0 +1,37 @@
+using MainCore.Constraints;
+
+namespace MainCore.Commands.UI.Misc
+{
+    [Handler]
+    public static partial class SaveTelegramSettingCommand
+    {
+        public sealed record Command(AccountId AccountId, bool IsEnabled, string BotToken, string ChatId) : IAccountCommand;
+
+        private static async ValueTask HandleAsync(
+            Command command,
+            AppDbContext context,
+            CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            var (accountId, isEnabled, botToken, chatId) = command;
+            var entity = context.TelegramSettings.FirstOrDefault(x => x.AccountId == accountId.Value);
+            if (entity is null)
+            {
+                context.TelegramSettings.Add(new TelegramSetting
+                {
+                    AccountId = accountId.Value,
+                    IsEnabled = isEnabled,
+                    BotToken = botToken,
+                    ChatId = chatId,
+                });
+            }
+            else
+            {
+                entity.IsEnabled = isEnabled;
+                entity.BotToken = botToken;
+                entity.ChatId = chatId;
+            }
+            context.SaveChanges();
+        }
+    }
+}

--- a/MainCore/Entities/TelegramSetting.cs
+++ b/MainCore/Entities/TelegramSetting.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MainCore.Entities
+{
+    public class TelegramSetting
+    {
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        public int AccountId { get; set; }
+        public bool IsEnabled { get; set; }
+        public string BotToken { get; set; } = string.Empty;
+        public string ChatId { get; set; } = string.Empty;
+    }
+}

--- a/MainCore/Infrasturecture/Persistence/AppDbContext.cs
+++ b/MainCore/Infrasturecture/Persistence/AppDbContext.cs
@@ -25,6 +25,7 @@ namespace MainCore.Infrasturecture.Persistence
         public DbSet<Storage> Storages { get; set; }
         public DbSet<VillageSetting> VillagesSetting { get; set; }
         public DbSet<Farm> FarmLists { get; set; }
+        public DbSet<TelegramSetting> TelegramSettings { get; set; }
 
         #endregion table
 
@@ -250,6 +251,27 @@ namespace MainCore.Infrasturecture.Persistence
             AddColumn("ProductionClay");
             AddColumn("ProductionIron");
             AddColumn("ProductionCrop");
+            Database.CloseConnection();
+        }
+
+        public void EnsureTelegramSettings()
+        {
+            using var command = Database.GetDbConnection().CreateCommand();
+            command.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='TelegramSettings'";
+            Database.OpenConnection();
+            var exists = command.ExecuteScalar() != null;
+            if (!exists)
+            {
+                using var create = Database.GetDbConnection().CreateCommand();
+                create.CommandText = @"CREATE TABLE \"TelegramSettings\" (
+                    \"Id\" INTEGER NOT NULL CONSTRAINT \"PK_TelegramSettings\" PRIMARY KEY AUTOINCREMENT,
+                    \"AccountId\" INTEGER NOT NULL,
+                    \"IsEnabled\" INTEGER NOT NULL,
+                    \"BotToken\" TEXT NOT NULL,
+                    \"ChatId\" TEXT NOT NULL
+                )";
+                create.ExecuteNonQuery();
+            }
             Database.CloseConnection();
         }
 

--- a/MainCore/Queries/GetTelegramSettingQuery.cs
+++ b/MainCore/Queries/GetTelegramSettingQuery.cs
@@ -1,0 +1,22 @@
+using MainCore.Constraints;
+
+namespace MainCore.Queries
+{
+    [Handler]
+    public static partial class GetTelegramSettingQuery
+    {
+        public sealed record Query(AccountId AccountId) : IAccountQuery;
+
+        private static async ValueTask<TelegramSetting?> HandleAsync(
+            Query query,
+            AppDbContext context,
+            CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            var accountId = query.AccountId;
+            var setting = context.TelegramSettings
+                .FirstOrDefault(x => x.AccountId == accountId.Value);
+            return setting;
+        }
+    }
+}

--- a/MainCore/UI/ViewModels/MainViewModel.cs
+++ b/MainCore/UI/ViewModels/MainViewModel.cs
@@ -41,6 +41,7 @@ namespace MainCore.UI.ViewModels
 
                 var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
                 var notExist = await context.Database.EnsureCreatedAsync();
+                context.EnsureTelegramSettings();
 
                 if (!notExist)
                 {


### PR DESCRIPTION
## Summary
- create `TelegramSetting` entity and table helper
- update `AppDbContext` to manage telegram settings
- ensure telegram table on startup
- add query and command for telegram settings

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b03f12f98832f8f0776d1d66ffb6e