### PR TITLE
Fix NPC task finalization

### DIFF
--- a/MainCore.Test/Parsers/NpcResourceParser.Test.cs
+++ b/MainCore.Test/Parsers/NpcResourceParser.Test.cs
@@ -64,5 +64,14 @@
             var result = MainCore.Parsers.NpcResourceParser.GetOkButton(_html);
             result.ShouldNotBeNull();
         }
+
+        [Fact]
+        public void IsOkButtonVisible()
+        {
+            _html.Load(DistributeDialog);
+            var result = MainCore.Parsers.NpcResourceParser.IsOkButtonVisible(_html);
+            result.ShouldBeFalse();
+        }
     }
 }
+

--- a/MainCore.Test/Parsers/NpcResourceParser.Test.cs
+++ b/MainCore.Test/Parsers/NpcResourceParser.Test.cs
@@ -48,5 +48,21 @@
             var result = MainCore.Parsers.NpcResourceParser.GetInputs(_html);
             result.Count().ShouldBe(4);
         }
+
+        [Fact]
+        public void GetDistributeButton()
+        {
+            _html.Load(DistributeDialog);
+            var result = MainCore.Parsers.NpcResourceParser.GetDistributeButton(_html);
+            result.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void GetOkButton()
+        {
+            _html.Load(DistributeDialog);
+            var result = MainCore.Parsers.NpcResourceParser.GetOkButton(_html);
+            result.ShouldNotBeNull();
+        }
     }
 }

--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -114,6 +114,40 @@ namespace MainCore.Commands.Features.NpcResource
             var result = await browser.Click(By.XPath(button.XPath));
             if (result.IsFailed) return result;
 
+            static bool DistributeShown(IWebDriver driver)
+            {
+                var doc = new HtmlDocument();
+                doc.LoadHtml(driver.PageSource);
+                return NpcResourceParser.GetDistributeButton(doc) is not null;
+            }
+
+            result = await browser.Wait(DistributeShown, cancellationToken);
+            if (result.IsFailed) return result;
+
+            html = browser.Html;
+            var distributeButton = NpcResourceParser.GetDistributeButton(html);
+            if (distributeButton is null) return Retry.ButtonNotFound("distribute remaining resources");
+
+            result = await browser.Click(By.XPath(distributeButton.XPath));
+            if (result.IsFailed) return result;
+
+            static bool OkShown(IWebDriver driver)
+            {
+                var doc = new HtmlDocument();
+                doc.LoadHtml(driver.PageSource);
+                return NpcResourceParser.GetOkButton(doc) is not null;
+            }
+
+            result = await browser.Wait(OkShown, cancellationToken);
+            if (result.IsFailed) return result;
+
+            html = browser.Html;
+            var okButton = NpcResourceParser.GetOkButton(html);
+            if (okButton is null) return Retry.ButtonNotFound("ok");
+
+            result = await browser.Click(By.XPath(okButton.XPath));
+            if (result.IsFailed) return result;
+
             return Result.Ok();
         }
     }

--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -131,22 +131,13 @@ namespace MainCore.Commands.Features.NpcResource
             result = await browser.Click(By.XPath(distributeButton.XPath));
             if (result.IsFailed) return result;
 
-            static bool OkShown(IWebDriver driver)
-            {
-                var doc = new HtmlDocument();
-                doc.LoadHtml(driver.PageSource);
-                return NpcResourceParser.IsOkButtonVisible(doc);
-            }
-
-            result = await browser.Wait(OkShown, cancellationToken);
-            if (result.IsFailed) return result;
-
             html = browser.Html;
             var okButton = NpcResourceParser.GetOkButton(html);
-            if (okButton is null) return Retry.ButtonNotFound("ok");
-
-            result = await browser.Click(By.XPath(okButton.XPath));
-            if (result.IsFailed) return result;
+            if (okButton is not null)
+            {
+                var okResult = await browser.Click(By.XPath(okButton.XPath));
+                if (okResult.IsFailed) return okResult;
+            }
 
             return Result.Ok();
         }

--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -139,6 +139,16 @@ namespace MainCore.Commands.Features.NpcResource
                 if (okResult.IsFailed) return okResult;
             }
 
+            static bool DialogClosed(IWebDriver driver)
+            {
+                var doc = new HtmlDocument();
+                doc.LoadHtml(driver.PageSource);
+                return !NpcResourceParser.IsNpcDialog(doc);
+            }
+
+            result = await browser.Wait(DialogClosed, cancellationToken);
+            if (result.IsFailed) return result;
+
             return Result.Ok();
         }
     }

--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -135,7 +135,7 @@ namespace MainCore.Commands.Features.NpcResource
             {
                 var doc = new HtmlDocument();
                 doc.LoadHtml(driver.PageSource);
-                return NpcResourceParser.GetOkButton(doc) is not null;
+                return NpcResourceParser.IsOkButtonVisible(doc);
             }
 
             result = await browser.Wait(OkShown, cancellationToken);

--- a/MainCore/Parsers/NpcResourceParser.cs
+++ b/MainCore/Parsers/NpcResourceParser.cs
@@ -55,5 +55,23 @@
             if (crop is null) throw new Exception("Crop input not found");
             yield return crop;
         }
+
+        public static HtmlNode? GetDistributeButton(HtmlDocument doc)
+        {
+            var submitText = doc.GetElementbyId("submitText");
+            if (submitText is null) return null;
+            if (submitText.GetAttributeValue("style", string.Empty).Contains("display: none")) return null;
+            var button = submitText.Descendants("button").FirstOrDefault();
+            return button;
+        }
+
+        public static HtmlNode? GetOkButton(HtmlDocument doc)
+        {
+            var button = doc.DocumentNode.Descendants("button").FirstOrDefault(x => x.HasClass("dialogButtonOk"));
+            if (button is null) return null;
+            var style = button.ParentNode?.GetAttributeValue("style", string.Empty) ?? string.Empty;
+            if (style.Contains("display: none")) return null;
+            return button;
+        }
     }
 }

--- a/MainCore/Parsers/NpcResourceParser.cs
+++ b/MainCore/Parsers/NpcResourceParser.cs
@@ -67,11 +67,19 @@
 
         public static HtmlNode? GetOkButton(HtmlDocument doc)
         {
-            var button = doc.DocumentNode.Descendants("button").FirstOrDefault(x => x.HasClass("dialogButtonOk"));
-            if (button is null) return null;
-            var style = button.ParentNode?.GetAttributeValue("style", string.Empty) ?? string.Empty;
-            if (style.Contains("display: none")) return null;
+            var button = doc.DocumentNode
+                .Descendants("button")
+                .FirstOrDefault(x => x.HasClass("dialogButtonOk"));
             return button;
+        }
+
+        public static bool IsOkButtonVisible(HtmlDocument doc)
+        {
+            var button = GetOkButton(doc);
+            if (button is null) return false;
+            var style = button.ParentNode?.GetAttributeValue("style", string.Empty) ?? string.Empty;
+            return !style.Contains("display: none");
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- ensure we close the NPC dialog so village tasks can continue
- support parsing NPC confirmation buttons
- test parser for new buttons

## Testing
- `dotnet test` *(fails: EnableWindowsTargeting required)*

------
https://chatgpt.com/codex/tasks/task_e_684b129e2590832f93e967f216575c2e