### PR TITLE
Fix upgrade duplication by detecting ongoing building upgrade

### DIFF
--- a/MainCore/Commands/Features/UpgradeBuilding/HandleUpgradeCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleUpgradeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MainCore.Constraints;
+using MainCore.Parsers;
 
 namespace MainCore.Commands.Features.UpgradeBuilding
 {
@@ -17,6 +18,12 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             var (accountId, villageId, plan) = command;
 
             Result result;
+
+            var upgradingLevel = UpgradeParser.GetUpgradingLevel(browser.Html);
+            if (upgradingLevel.HasValue && upgradingLevel.Value >= plan.Level)
+            {
+                return Continue.Error;
+            }
 
             if (context.IsUpgradeable(villageId, plan))
             {

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -1,4 +1,6 @@
-﻿namespace MainCore.Parsers
+using System.Text.RegularExpressions;
+
+namespace MainCore.Parsers
 {
     public static class UpgradeParser
     {
@@ -77,6 +79,18 @@
             var button = upgradeButtonsContainer.Descendants("button")
                 .FirstOrDefault(x => x.HasClass("build"));
             return button;
+        }
+
+        public static int? GetUpgradingLevel(HtmlDocument doc)
+        {
+            var contract = doc.GetElementbyId("contract");
+            if (contract is null) return null;
+
+            var text = contract.InnerText;
+            var match = Regex.Match(text, @"Currently upgrading to level\s*(\d+)", RegexOptions.IgnoreCase);
+            if (!match.Success) return null;
+            if (int.TryParse(match.Groups[1].Value, out var level)) return level;
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate building upgrades
- parse building page for current upgrade level
- skip upgrade if building is already upgrading

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcdcccd84832fbd4ed76d17cab0f6