### PR TITLE
Fix NPC task completion waiting on dialog

### DIFF
--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -114,31 +114,6 @@ namespace MainCore.Commands.Features.NpcResource
             var result = await browser.Click(By.XPath(button.XPath));
             if (result.IsFailed) return result;
 
-            static bool DistributeShown(IWebDriver driver)
-            {
-                var doc = new HtmlDocument();
-                doc.LoadHtml(driver.PageSource);
-                return NpcResourceParser.GetDistributeButton(doc) is not null;
-            }
-
-            result = await browser.Wait(DistributeShown, cancellationToken);
-            if (result.IsFailed) return result;
-
-            html = browser.Html;
-            var distributeButton = NpcResourceParser.GetDistributeButton(html);
-            if (distributeButton is null) return Retry.ButtonNotFound("distribute remaining resources");
-
-            result = await browser.Click(By.XPath(distributeButton.XPath));
-            if (result.IsFailed) return result;
-
-            html = browser.Html;
-            var okButton = NpcResourceParser.GetOkButton(html);
-            if (okButton is not null)
-            {
-                var okResult = await browser.Click(By.XPath(okButton.XPath));
-                if (okResult.IsFailed) return okResult;
-            }
-
             static bool DialogClosed(IWebDriver driver)
             {
                 var doc = new HtmlDocument();

--- a/MainCore/Parsers/NpcResourceParser.cs
+++ b/MainCore/Parsers/NpcResourceParser.cs
@@ -5,7 +5,16 @@
         public static bool IsNpcDialog(HtmlDocument doc)
         {
             var dialog = doc.GetElementbyId("npc");
-            return dialog is not null;
+            if (dialog is null) return false;
+
+            var node = dialog;
+            while (node is not null)
+            {
+                var style = node.GetAttributeValue("style", string.Empty);
+                if (style.Contains("display: none", StringComparison.OrdinalIgnoreCase)) return false;
+                node = node.ParentNode;
+            }
+            return true;
         }
 
         public static HtmlNode? GetExchangeResourcesButton(HtmlDocument doc)


### PR DESCRIPTION
## Summary
- simplify NPC trade completion logic by just waiting for the dialog to disappear

## Testing
- `dotnet test TravBotSharp.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bebd7ae24832f9276b3c07bb2fb59