### PR TITLE
Add telegram command to display tasks

### DIFF
--- a/MainCore/Services/TelegramCommandService.cs
+++ b/MainCore/Services/TelegramCommandService.cs
@@ -1,0 +1,39 @@
+using System.Text;
+
+namespace MainCore.Services
+{
+    [RegisterSingleton<TelegramCommandService>]
+    public sealed class TelegramCommandService
+    {
+        private readonly ITelegramService _telegramService;
+        private readonly ITaskManager _taskManager;
+
+        public TelegramCommandService(ITelegramService telegramService, ITaskManager taskManager)
+        {
+            _telegramService = telegramService;
+            _taskManager = taskManager;
+            _telegramService.CommandReceived += OnCommandReceived;
+        }
+
+        private async void OnCommandReceived(AccountId accountId, string message)
+        {
+            if (!string.Equals(message.Trim(), "tasks", StringComparison.OrdinalIgnoreCase)) return;
+
+            var tasks = _taskManager.GetTaskList(accountId);
+            if (tasks.Count == 0)
+            {
+                await _telegramService.SendText("No tasks in queue", accountId);
+                return;
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Task\tExecute at\tStage");
+            foreach (var task in tasks)
+            {
+                sb.AppendLine($"{task.Description}\t{task.ExecuteAt:yyyy-MM-dd HH:mm:ss}\t{task.Stage}");
+            }
+
+            await _telegramService.SendText(sb.ToString(), accountId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TelegramCommandService` that listens to `ITelegramService.CommandReceived`
- when telegram message `tasks` is received, respond with queued tasks information

## Testing
- `dotnet build MainCore/MainCore.csproj --no-restore`
- `dotnet test MainCore.Test/MainCore.Test.csproj --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_684bf3eaadcc832f9dca98fa9b558d55