### PR TITLE
Fix upgrade queue detection

### DIFF
--- a/MainCore.Test/Parsers/Upgrade/CroplandUpgradingDouble.html
+++ b/MainCore.Test/Parsers/Upgrade/CroplandUpgradingDouble.html
@@ -1,0 +1,6 @@
+<div id="contract">
+<table>
+<tr class="underConstruction"><th>Currently upgrading to level 9:</th><td>203 per hour</td></tr>
+<tr class="underConstruction"><th>Currently upgrading to level 10:</th><td>280 per hour</td></tr>
+</table>
+</div>

--- a/MainCore.Test/Parsers/Upgrade/CroplandUpgradingSingle.html
+++ b/MainCore.Test/Parsers/Upgrade/CroplandUpgradingSingle.html
@@ -1,0 +1,5 @@
+<div id="contract">
+<table>
+<tr class="underConstruction"><th>Currently upgrading to level 9:</th><td>203 per hour</td></tr>
+</table>
+</div>

--- a/MainCore.Test/Parsers/UpgradeParser.Test.cs
+++ b/MainCore.Test/Parsers/UpgradeParser.Test.cs
@@ -9,6 +9,8 @@ namespace MainCore.Test.Parsers
         private const string MarketplaceWithoutResource = "Parsers/Upgrade/MarketplaceWithoutResource.html";
         private const string CroplandConstructed = "Parsers/Upgrade/CroplandConstructed.html";
         private const string CroplandEmpty = "Parsers/Upgrade/CroplandEmpty.html";
+        private const string CroplandUpgradingSingle = "Parsers/Upgrade/CroplandUpgradingSingle.html";
+        private const string CroplandUpgradingDouble = "Parsers/Upgrade/CroplandUpgradingDouble.html";
 
         [Theory]
         [InlineData(CrannyEmpty, BuildingEnums.Cranny)]
@@ -59,6 +61,22 @@ namespace MainCore.Test.Parsers
             _html.Load(path);
             var actual = MainCore.Parsers.UpgradeParser.GetSpecialUpgradeButton(_html);
             actual.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void GetUpgradingLevel_Single()
+        {
+            _html.Load(CroplandUpgradingSingle);
+            var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
+            actual.ShouldBe(9);
+        }
+
+        [Fact]
+        public void GetUpgradingLevel_Multiple()
+        {
+            _html.Load(CroplandUpgradingDouble);
+            var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
+            actual.ShouldBe(10);
         }
     }
 }

--- a/MainCore/Commands/Features/UpgradeBuilding/HandleUpgradeCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleUpgradeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MainCore.Constraints;
+using MainCore.Parsers;
 
 namespace MainCore.Commands.Features.UpgradeBuilding
 {
@@ -17,6 +18,12 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             var (accountId, villageId, plan) = command;
 
             Result result;
+
+            var upgradingLevel = UpgradeParser.GetUpgradingLevel(browser.Html);
+            if (upgradingLevel.HasValue && upgradingLevel.Value >= plan.Level)
+            {
+                return Continue.Error;
+            }
 
             if (context.IsUpgradeable(villageId, plan))
             {

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -1,4 +1,6 @@
-﻿namespace MainCore.Parsers
+using System.Text.RegularExpressions;
+
+namespace MainCore.Parsers
 {
     public static class UpgradeParser
     {
@@ -77,6 +79,25 @@
             var button = upgradeButtonsContainer.Descendants("button")
                 .FirstOrDefault(x => x.HasClass("build"));
             return button;
+        }
+
+        public static int? GetUpgradingLevel(HtmlDocument doc)
+        {
+            var contract = doc.GetElementbyId("contract");
+            if (contract is null) return null;
+
+            var text = contract.InnerText;
+            var matches = Regex.Matches(text, @"Currently upgrading to level\s*(\d+)", RegexOptions.IgnoreCase);
+            int? level = null;
+            foreach (Match match in matches)
+            {
+                if (!match.Success) continue;
+                if (int.TryParse(match.Groups[1].Value, out var value))
+                {
+                    if (level is null || value > level) level = value;
+                }
+            }
+            return level;
         }
     }
 }


### PR DESCRIPTION
## Summary
- enhance `GetUpgradingLevel` to consider multiple upgrade entries
- test upgrade level parsing with single and multiple queued levels

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcdcccd84832fbd4ed76d17cab0f6