### PR TITLE
Fix NPC trade button handling

### DIFF
--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -109,35 +109,14 @@ namespace MainCore.Commands.Features.NpcResource
             var html = browser.Html;
 
             var button = NpcResourceParser.GetRedeemButton(html);
-            if (button is null) return Retry.ButtonNotFound("redeem");
+            if (button is null)
+            {
+                button = NpcResourceParser.GetDistributeButton(html);
+                if (button is null) return Retry.ButtonNotFound("redeem");
+            }
 
             var result = await browser.Click(By.XPath(button.XPath));
             if (result.IsFailed) return result;
-
-            static bool DistributeShown(IWebDriver driver)
-            {
-                var doc = new HtmlDocument();
-                doc.LoadHtml(driver.PageSource);
-                return NpcResourceParser.GetDistributeButton(doc) is not null;
-            }
-
-            result = await browser.Wait(DistributeShown, cancellationToken);
-            if (result.IsFailed) return result;
-
-            html = browser.Html;
-            var distributeButton = NpcResourceParser.GetDistributeButton(html);
-            if (distributeButton is null) return Retry.ButtonNotFound("distribute remaining resources");
-
-            result = await browser.Click(By.XPath(distributeButton.XPath));
-            if (result.IsFailed) return result;
-
-            html = browser.Html;
-            var okButton = NpcResourceParser.GetOkButton(html);
-            if (okButton is not null)
-            {
-                var okResult = await browser.Click(By.XPath(okButton.XPath));
-                if (okResult.IsFailed) return okResult;
-            }
 
             static bool DialogClosed(IWebDriver driver)
             {

--- a/MainCore/Parsers/NpcResourceParser.cs
+++ b/MainCore/Parsers/NpcResourceParser.cs
@@ -5,7 +5,16 @@
         public static bool IsNpcDialog(HtmlDocument doc)
         {
             var dialog = doc.GetElementbyId("npc");
-            return dialog is not null;
+            if (dialog is null) return false;
+
+            var node = dialog;
+            while (node is not null)
+            {
+                var style = node.GetAttributeValue("style", string.Empty);
+                if (style.Contains("display: none", StringComparison.OrdinalIgnoreCase)) return false;
+                node = node.ParentNode;
+            }
+            return true;
         }
 
         public static HtmlNode? GetExchangeResourcesButton(HtmlDocument doc)
@@ -20,9 +29,13 @@
             return exchangeResourceButton;
         }
 
-        public static HtmlNode GetRedeemButton(HtmlDocument doc)
+        public static HtmlNode? GetRedeemButton(HtmlDocument doc)
         {
-            var button = doc.GetElementbyId("npc_market_button");
+            var submitButton = doc.GetElementbyId("submitButton");
+            if (submitButton is null) return null;
+            if (submitButton.GetAttributeValue("style", string.Empty).Contains("display: none", StringComparison.OrdinalIgnoreCase))
+                return null;
+            var button = submitButton.Descendants("button").FirstOrDefault();
             return button;
         }
 


### PR DESCRIPTION
## Summary
- detect visible Redeem button via `submitButton` parent
- click either Redeem or Distribute Remaining Resources depending on which is visible

## Testing
- `dotnet test TravBotSharp.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bebd7ae24832f9276b3c07bb2fb59