### PR TITLE
Fix OnlyCrop resource plan

### DIFF
--- a/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
@@ -69,8 +69,34 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             List<BuildingItem> layoutBuildings
         )
         {
+            var fieldList = new Dictionary<ResourcePlanEnums, List<BuildingEnums>>()
+            {
+                {
+                    ResourcePlanEnums.AllResources,
+                    new()
+                    {
+                        BuildingEnums.Woodcutter,
+                        BuildingEnums.ClayPit,
+                        BuildingEnums.IronMine,
+                        BuildingEnums.Cropland,
+                    }
+                },
+                {
+                    ResourcePlanEnums.ExcludeCrop,
+                    new()
+                    {
+                        BuildingEnums.Woodcutter,
+                        BuildingEnums.ClayPit,
+                        BuildingEnums.IronMine,
+                    }
+                },
+                { ResourcePlanEnums.OnlyCrop, new() { BuildingEnums.Cropland, } },
+            };
+
+            var fieldTypes = fieldList[plan.Plan];
+
             layoutBuildings = layoutBuildings
-                .Where(x => GetJobQuery.ResourceTypes.Contains(x.Type))
+                .Where(x => fieldTypes.Contains(x.Type))
                 .Where(x => x.Level < plan.Level)
                 .ToList();
 


### PR DESCRIPTION
## Summary
- ensure resource build tasks obey selected plan when converting to specific building upgrades

## Testing
- `dotnet build MainCore/MainCore.csproj`
- `dotnet test` *(fails: project targets Windows)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c969d1c832f99aada1ceec7ac86