### PR TITLE
Fix upgrading level detection

### DIFF
--- a/MainCore.Test/Parsers/Upgrade/CroplandUpgradingNbsp.html
+++ b/MainCore.Test/Parsers/Upgrade/CroplandUpgradingNbsp.html
@@ -1,0 +1,6 @@
+<div id="build" class="gid4 level9">
+    <table id="build_value" class="transparent">
+        <tr class="currentLevel"><th>Current production:</th><td><span class="number">203</span> per hour</td></tr>
+        <tr class="underConstruction"><th>Currently upgrading to level&nbsp;10:</th><td><span class="number">280</span> per hour</td></tr>
+    </table>
+</div>

--- a/MainCore.Test/Parsers/Upgrade/CroplandUpgradingTable.html
+++ b/MainCore.Test/Parsers/Upgrade/CroplandUpgradingTable.html
@@ -1,0 +1,6 @@
+<div id="build" class="gid4 level9">
+    <table id="build_value" class="transparent">
+        <tr class="currentLevel"><th>Current production:</th><td><span class="number">203</span> per hour</td></tr>
+        <tr class="underConstruction"><th>Currently upgrading to level 10:</th><td><span class="number">280</span> per hour</td></tr>
+    </table>
+</div>

--- a/MainCore.Test/Parsers/UpgradeParser.Test.cs
+++ b/MainCore.Test/Parsers/UpgradeParser.Test.cs
@@ -11,6 +11,7 @@ namespace MainCore.Test.Parsers
         private const string CroplandEmpty = "Parsers/Upgrade/CroplandEmpty.html";
         private const string CroplandUpgradingSingle = "Parsers/Upgrade/CroplandUpgradingSingle.html";
         private const string CroplandUpgradingDouble = "Parsers/Upgrade/CroplandUpgradingDouble.html";
+        private const string CroplandUpgradingTable = "Parsers/Upgrade/CroplandUpgradingTable.html";
 
         [Theory]
         [InlineData(CrannyEmpty, BuildingEnums.Cranny)]
@@ -75,6 +76,14 @@ namespace MainCore.Test.Parsers
         public void GetUpgradingLevel_Multiple()
         {
             _html.Load(CroplandUpgradingDouble);
+            var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
+            actual.ShouldBe(10);
+        }
+
+        [Fact]
+        public void GetUpgradingLevel_BuildValueTable()
+        {
+            _html.Load(CroplandUpgradingTable);
             var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
             actual.ShouldBe(10);
         }

--- a/MainCore.Test/Parsers/UpgradeParser.Test.cs
+++ b/MainCore.Test/Parsers/UpgradeParser.Test.cs
@@ -12,6 +12,7 @@ namespace MainCore.Test.Parsers
         private const string CroplandUpgradingSingle = "Parsers/Upgrade/CroplandUpgradingSingle.html";
         private const string CroplandUpgradingDouble = "Parsers/Upgrade/CroplandUpgradingDouble.html";
         private const string CroplandUpgradingTable = "Parsers/Upgrade/CroplandUpgradingTable.html";
+        private const string CroplandUpgradingNbsp = "Parsers/Upgrade/CroplandUpgradingNbsp.html";
 
         [Theory]
         [InlineData(CrannyEmpty, BuildingEnums.Cranny)]
@@ -84,6 +85,14 @@ namespace MainCore.Test.Parsers
         public void GetUpgradingLevel_BuildValueTable()
         {
             _html.Load(CroplandUpgradingTable);
+            var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
+            actual.ShouldBe(10);
+        }
+
+        [Fact]
+        public void GetUpgradingLevel_Nbsp()
+        {
+            _html.Load(CroplandUpgradingNbsp);
             var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
             actual.ShouldBe(10);
         }

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -89,15 +89,22 @@ namespace MainCore.Parsers
                 doc.GetElementbyId("build_value")
             };
 
+            // some pages only show a small info box when a building is being upgraded
+            var upgradeBuilding = doc.DocumentNode
+                .Descendants("div")
+                .FirstOrDefault(x => x.HasClass("upgradeBuilding"));
+            if (upgradeBuilding is not null) containers.Add(upgradeBuilding);
+
             int? level = null;
 
             foreach (var container in containers)
             {
                 if (container is null) continue;
 
-                var rows = container.Descendants("tr")
+                var rows = container.Descendants()
                     .Where(x => x.HasClass("underConstruction") ||
-                                x.InnerText.Contains("upgrading", StringComparison.OrdinalIgnoreCase));
+                                x.InnerText.Contains("upgrading", StringComparison.OrdinalIgnoreCase) ||
+                                x.InnerText.Contains("extended", StringComparison.OrdinalIgnoreCase));
 
                 foreach (var row in rows)
                 {

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -108,7 +108,8 @@ namespace MainCore.Parsers
 
                 foreach (var row in rows)
                 {
-                    var match = Regex.Match(row.InnerText, @"level\s*(\d+)", RegexOptions.IgnoreCase);
+                    var text = HtmlEntity.DeEntitize(row.InnerText).Replace('\u00A0', ' ');
+                    var match = Regex.Match(text, @"level(?:\s|\u00A0)*(\d+)", RegexOptions.IgnoreCase);
                     if (!match.Success) continue;
                     if (int.TryParse(match.Groups[1].Value, out var value))
                     {

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -108,7 +108,7 @@ namespace MainCore.Parsers
 
                 foreach (var row in rows)
                 {
-                    var text = HtmlEntity.DeEntitize(row.InnerText).Replace('\u00A0', ' ');
+                    var text = HtmlEntity.DeEntitize(row.InnerText ?? string.Empty).Replace('\u00A0', ' ');
                     var match = Regex.Match(text, @"level(?:\s|\u00A0)*(\d+)", RegexOptions.IgnoreCase);
                     if (!match.Success) continue;
                     if (int.TryParse(match.Groups[1].Value, out var value))

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -106,9 +106,11 @@ namespace MainCore.Parsers
                                 x.InnerText.Contains("upgrading", StringComparison.OrdinalIgnoreCase) ||
                                 x.InnerText.Contains("extended", StringComparison.OrdinalIgnoreCase));
 
+#pragma warning disable CS8602 // row.InnerText may be null in older HTMLAgilityPack versions
                 foreach (var row in rows)
                 {
-                    var text = HtmlEntity.DeEntitize(row?.InnerText ?? string.Empty).Replace('\u00A0', ' ');
+                    var text = HtmlEntity.DeEntitize(row.InnerText ?? string.Empty).Replace('\u00A0', ' ');
+#pragma warning restore CS8602
                     var match = Regex.Match(text, @"level(?:\s|\u00A0)*(\d+)", RegexOptions.IgnoreCase);
                     if (!match.Success) continue;
                     if (int.TryParse(match.Groups[1].Value, out var value))

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -83,20 +83,30 @@ namespace MainCore.Parsers
 
         public static int? GetUpgradingLevel(HtmlDocument doc)
         {
-            var contract = doc.GetElementbyId("contract");
-            if (contract is null) return null;
-
-            var text = contract.InnerText;
-            var matches = Regex.Matches(text, @"Currently upgrading to level\s*(\d+)", RegexOptions.IgnoreCase);
-            int? level = null;
-            foreach (Match match in matches)
+            var containers = new List<HtmlNode?>
             {
-                if (!match.Success) continue;
-                if (int.TryParse(match.Groups[1].Value, out var value))
+                doc.GetElementbyId("contract"),
+                doc.GetElementbyId("build_value")
+            };
+
+            int? level = null;
+
+            foreach (var container in containers)
+            {
+                if (container is null) continue;
+
+                var text = container.InnerText;
+                var matches = Regex.Matches(text, @"Currently upgrading to level\s*(\d+)", RegexOptions.IgnoreCase);
+                foreach (Match match in matches)
                 {
-                    if (level is null || value > level) level = value;
+                    if (!match.Success) continue;
+                    if (int.TryParse(match.Groups[1].Value, out var value))
+                    {
+                        if (level is null || value > level) level = value;
+                    }
                 }
             }
+
             return level;
         }
     }

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -108,7 +108,7 @@ namespace MainCore.Parsers
 
                 foreach (var row in rows)
                 {
-                    var text = HtmlEntity.DeEntitize(row.InnerText ?? string.Empty).Replace('\u00A0', ' ');
+                    var text = HtmlEntity.DeEntitize(row?.InnerText ?? string.Empty).Replace('\u00A0', ' ');
                     var match = Regex.Match(text, @"level(?:\s|\u00A0)*(\d+)", RegexOptions.IgnoreCase);
                     if (!match.Success) continue;
                     if (int.TryParse(match.Groups[1].Value, out var value))

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -95,10 +95,13 @@ namespace MainCore.Parsers
             {
                 if (container is null) continue;
 
-                var text = container.InnerText;
-                var matches = Regex.Matches(text, @"Currently upgrading to level\s*(\d+)", RegexOptions.IgnoreCase);
-                foreach (Match match in matches)
+                var rows = container.Descendants("tr")
+                    .Where(x => x.HasClass("underConstruction") ||
+                                x.InnerText.Contains("upgrading", StringComparison.OrdinalIgnoreCase));
+
+                foreach (var row in rows)
                 {
+                    var match = Regex.Match(row.InnerText, @"level\s*(\d+)", RegexOptions.IgnoreCase);
                     if (!match.Success) continue;
                     if (int.TryParse(match.Groups[1].Value, out var value))
                     {


### PR DESCRIPTION
## Summary
- fix upgrade parser to detect progress when `#contract` element is missing
- add regression test for upgrade detection from build_value table

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c51adad70832fadb2f167f0a2a9a4