### PR TITLE
Add pre-upgrade check for existing construction

### DIFF
--- a/MainCore.Test/Parsers/Upgrade/CroplandMaxLevel.html
+++ b/MainCore.Test/Parsers/Upgrade/CroplandMaxLevel.html
@@ -1,0 +1,3 @@
+<div id="contract">
+Construction of maximum possible building level is currently running.
+</div>

--- a/MainCore.Test/Parsers/UpgradeParser.Test.cs
+++ b/MainCore.Test/Parsers/UpgradeParser.Test.cs
@@ -11,6 +11,7 @@ namespace MainCore.Test.Parsers
         private const string CroplandEmpty = "Parsers/Upgrade/CroplandEmpty.html";
         private const string CroplandUpgradingSingle = "Parsers/Upgrade/CroplandUpgradingSingle.html";
         private const string CroplandUpgradingDouble = "Parsers/Upgrade/CroplandUpgradingDouble.html";
+        private const string CroplandMaxLevel = "Parsers/Upgrade/CroplandMaxLevel.html";
 
         [Theory]
         [InlineData(CrannyEmpty, BuildingEnums.Cranny)]
@@ -77,6 +78,14 @@ namespace MainCore.Test.Parsers
             _html.Load(CroplandUpgradingDouble);
             var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
             actual.ShouldBe(10);
+        }
+
+        [Fact]
+        public void IsMaxLevelUnderConstruction_Test()
+        {
+            _html.Load(CroplandMaxLevel);
+            var actual = MainCore.Parsers.UpgradeParser.IsMaxLevelUnderConstruction(_html);
+            actual.ShouldBeTrue();
         }
     }
 }

--- a/MainCore/Commands/Features/UpgradeBuilding/CheckBuildingPageCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/CheckBuildingPageCommand.cs
@@ -1,0 +1,35 @@
+using MainCore.Constraints;
+using MainCore.Parsers;
+
+namespace MainCore.Commands.Features.UpgradeBuilding
+{
+    [Handler]
+    public static partial class CheckBuildingPageCommand
+    {
+        public sealed record Command(AccountId AccountId, VillageId VillageId, NormalBuildPlan Plan, JobId JobId) : IAccountVillageCommand;
+
+        private static async ValueTask<Result> HandleAsync(
+            Command command,
+            IChromeBrowser browser,
+            DeleteJobByIdCommand.Handler deleteJobByIdCommand,
+            JobUpdated.Handler jobUpdated,
+            CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            var (accountId, villageId, plan, jobId) = command;
+
+            var html = browser.Html;
+            var upgradingLevel = UpgradeParser.GetUpgradingLevel(html);
+            var maxLevelRunning = UpgradeParser.IsMaxLevelUnderConstruction(html);
+
+            if (maxLevelRunning || (upgradingLevel.HasValue && upgradingLevel.Value >= plan.Level))
+            {
+                await deleteJobByIdCommand.HandleAsync(new(villageId, jobId), cancellationToken);
+                await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
+                return Continue.Error;
+            }
+
+            return Result.Ok();
+        }
+    }
+}

--- a/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
@@ -7,8 +7,9 @@ namespace MainCore.Commands.Features.UpgradeBuilding
     public static partial class HandleJobCommand
     {
         public sealed record Command(AccountId AccountId, VillageId VillageId) : IAccountVillageCommand;
+        public sealed record Response(NormalBuildPlan Plan, JobId JobId);
 
-        private static async ValueTask<Result<NormalBuildPlan>> HandleAsync(
+        private static async ValueTask<Result<Response>> HandleAsync(
             Command command,
             GetJobQuery.Handler getJobQuery,
             ToDorfCommand.Handler toDorfCommand,
@@ -40,7 +41,7 @@ namespace MainCore.Commands.Features.UpgradeBuilding
                     await addJobCommand.HandleAsync(new(villageId, normalBuildPlan.ToJob(), true));
                 }
                 await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
-                return Continue.Error;
+                return Result.Fail<Response>(new Continue());
             }
 
             var plan = JsonSerializer.Deserialize<NormalBuildPlan>(job.Content)!;
@@ -57,10 +58,10 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             {
                 await deleteJobByIdCommand.HandleAsync(new(villageId, job.Id), cancellationToken);
                 await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
-                return Continue.Error;
+                return Result.Fail<Response>(new Continue());
             }
 
-            return plan;
+            return Result.Ok(new Response(plan, job.Id));
         }
 
         private static NormalBuildPlan? GetNormalBuildPlan(

--- a/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
@@ -41,7 +41,7 @@ namespace MainCore.Commands.Features.UpgradeBuilding
                     await addJobCommand.HandleAsync(new(villageId, normalBuildPlan.ToJob(), true));
                 }
                 await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
-                return Result.Fail<Response>(new Continue());
+                return Result.Fail<Response>(Continue.Error);
             }
 
             var plan = JsonSerializer.Deserialize<NormalBuildPlan>(job.Content)!;
@@ -58,7 +58,7 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             {
                 await deleteJobByIdCommand.HandleAsync(new(villageId, job.Id), cancellationToken);
                 await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
-                return Result.Fail<Response>(new Continue());
+                return Result.Fail<Response>(Continue.Error);
             }
 
             return Result.Ok(new Response(plan, job.Id));

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -99,5 +99,13 @@ namespace MainCore.Parsers
             }
             return level;
         }
+
+        public static bool IsMaxLevelUnderConstruction(HtmlDocument doc)
+        {
+            var contract = doc.GetElementbyId("contract");
+            if (contract is null) return false;
+            var text = contract.InnerText;
+            return text.Contains("Construction of maximum possible building level is currently running", StringComparison.OrdinalIgnoreCase);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- detect when construction already going on at a building
- provide command to remove queued job when maximum level is upgrading
- handle job return structure to include JobId
- validate the construction state before using resources
- test parser for max-level upgrade text

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce34120e8832fb36dc548827720c1