### PR TITLE
Improve upgrade checks via title parsing

### DIFF
--- a/MainCore.Test/FakeDbContextFactory.cs
+++ b/MainCore.Test/FakeDbContextFactory.cs
@@ -11,6 +11,8 @@ namespace MainCore.Test
 
         public AppDbContext CreateDbContext(bool setup = false)
         {
+            SQLitePCL.Batteries_V2.Init();
+
             var connection = new SqliteConnection(_connectionString);
             connection.Open();
 

--- a/MainCore.Test/Parsers/BuildingLayout/UnderConstructionTitle.html
+++ b/MainCore.Test/Parsers/BuildingLayout/UnderConstructionTitle.html
@@ -1,3 +1,6 @@
 <div id="resourceFieldContainer">
-<a href="/build.php?id=7" class=" level colorLayer resourceField gid4 buildingSlot7 underConstruction level8" data-aid="7" data-gid="4" title="Cropland <span class=\"level\">Level 8</span>||<span class=\"notice\">Currently upgrading to level 9.</span><br /><span class=\"notice\">Currently upgrading to level 10.</span><br />Construction of maximum possible building level is currently running."><div class="labelLayer">8</div></a>
+<a href="/build.php?id=7"
+                     class=" level colorLayer resourceField gid4 buildingSlot7 underConstruction level8"
+                    data-aid="7" data-gid="4"
+                    title="Cropland &lt;span class=&quot;level&quot;&gt;Level 8&lt;/span&gt;||&lt;span class=&quot;notice&quot;&gt;Currently upgrading to level 9.&lt;/span&gt;&lt;br /&gt;&lt;span class=&quot;notice&quot;&gt;Currently upgrading to level 10.&lt;/span&gt;&lt;br /&gt;Construction of maximum possible building level is currently running."><div class="labelLayer">8</div></a>
 </div>

--- a/MainCore.Test/Parsers/BuildingLayout/UnderConstructionTitle.html
+++ b/MainCore.Test/Parsers/BuildingLayout/UnderConstructionTitle.html
@@ -1,0 +1,3 @@
+<div id="resourceFieldContainer">
+<a href="/build.php?id=7" class=" level colorLayer resourceField gid4 buildingSlot7 underConstruction level8" data-aid="7" data-gid="4" title="Cropland <span class=\"level\">Level 8</span>||<span class=\"notice\">Currently upgrading to level 9.</span><br /><span class=\"notice\">Currently upgrading to level 10.</span><br />Construction of maximum possible building level is currently running."><div class="labelLayer">8</div></a>
+</div>

--- a/MainCore.Test/Parsers/BuildingLayout/UnderConstructionTitleVariant.html
+++ b/MainCore.Test/Parsers/BuildingLayout/UnderConstructionTitleVariant.html
@@ -1,0 +1,3 @@
+<div id="resourceFieldContainer">
+<a href="/build.php?id=13" class=" level colorLayer resourceField gid4 buildingSlot13 underConstruction level8" data-aid="13" data-gid="4" title="Cropland &lt;span class=&quot;level&quot;&gt;Level 8&lt;/span&gt;||&lt;span class=&quot;notice&quot;&gt;Currently being upgraded to level 9&lt;/span&gt;"><div class="labelLayer">8</div></a>
+</div>

--- a/MainCore.Test/Parsers/BuildingLayoutParser.Test.cs
+++ b/MainCore.Test/Parsers/BuildingLayoutParser.Test.cs
@@ -1,5 +1,6 @@
 ﻿using MainCore.Enums;
 using Shouldly;
+using System.Collections.Generic;
 
 namespace MainCore.Test.Parsers
 {
@@ -9,6 +10,7 @@ namespace MainCore.Test.Parsers
         private const string Resources = "Parsers/BuildingLayout/Resources.html";
         private const string BuildingsWithWall = "Parsers/BuildingLayout/BuildingsWithWall.html";
         private const string BuildingsWithQueue = "Parsers/BuildingLayout/BuildingsWithQueue.html";
+        private const string UnderConstructionTitle = "Parsers/BuildingLayout/UnderConstructionTitle.html";
 
         [Fact]
         public void GetFields()
@@ -46,6 +48,15 @@ namespace MainCore.Test.Parsers
             _html.Load(path);
             var actual = MainCore.Parsers.BuildingLayoutParser.GetQueueBuilding(_html);
             actual.Count(x => x.Level != -1).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void GetTitleUpgradeInfo()
+        {
+            _html.Load(UnderConstructionTitle);
+            var (levels, isMax) = MainCore.Parsers.BuildingLayoutParser.GetTitleUpgradeInfo(_html, 7);
+            levels.ShouldBe(new List<int> { 9, 10 });
+            isMax.ShouldBeTrue();
         }
     }
 }

--- a/MainCore.Test/Parsers/BuildingLayoutParser.Test.cs
+++ b/MainCore.Test/Parsers/BuildingLayoutParser.Test.cs
@@ -58,5 +58,14 @@ namespace MainCore.Test.Parsers
             levels.ShouldBe(new List<int> { 9, 10 });
             isMax.ShouldBeTrue();
         }
+
+        [Fact]
+        public void GetTitleUpgradeInfo_Variant()
+        {
+            _html.Load("Parsers/BuildingLayout/UnderConstructionTitleVariant.html");
+            var (levels, isMax) = MainCore.Parsers.BuildingLayoutParser.GetTitleUpgradeInfo(_html, 13);
+            levels.ShouldBe(new List<int> { 9 });
+            isMax.ShouldBeFalse();
+        }
     }
 }

--- a/MainCore/Tasks/UpgradeBuildingTask.cs
+++ b/MainCore/Tasks/UpgradeBuildingTask.cs
@@ -33,7 +33,7 @@ namespace MainCore.Tasks
             {
                 if (cancellationToken.IsCancellationRequested) return Cancel.Error;
 
-                var (_, isFailed, plan, errors) = await handleJobCommand.HandleAsync(new(task.AccountId, task.VillageId), cancellationToken);
+                var (_, isFailed, plan, errors) = await handleJobCommand.HandleAsync(new(task.AccountId, task.VillageId), browser, logger, cancellationToken);
                 if (isFailed)
                 {
                     if (errors.OfType<Continue>().Any()) continue;

--- a/MainCore/Tasks/UpgradeBuildingTask.cs
+++ b/MainCore/Tasks/UpgradeBuildingTask.cs
@@ -33,7 +33,7 @@ namespace MainCore.Tasks
             {
                 if (cancellationToken.IsCancellationRequested) return Cancel.Error;
 
-                var (_, isFailed, plan, errors) = await handleJobCommand.HandleAsync(new(task.AccountId, task.VillageId), browser, logger, cancellationToken);
+                var (_, isFailed, plan, errors) = await handleJobCommand.HandleAsync(new(task.AccountId, task.VillageId), cancellationToken);
                 if (isFailed)
                 {
                     if (errors.OfType<Continue>().Any()) continue;


### PR DESCRIPTION
## Summary
- parse upgrading info from slot title with `GetTitleUpgradeInfo`
- log upgrade info and delete queued jobs when upgrades already running
- expose browser/logger in `HandleJobCommand`
- adjust upgrade task to use updated handler
- add tests for title parsing

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db516e274832f9713caca07cdbf6a