### PR TITLE
Randomize hero resource usage order

### DIFF
--- a/MainCore/Commands/Features/UseHeroItem/UseHeroResourceCommand.cs
+++ b/MainCore/Commands/Features/UseHeroItem/UseHeroResourceCommand.cs
@@ -31,15 +31,15 @@ namespace MainCore.Commands.Features.UseHeroItem
             var result = IsEnoughResource(resourceItems, resource);
             if (result.IsFailed) return result;
 
-            var items = new Dictionary<HeroItemEnums, long>
+            var items = new List<(HeroItemEnums Item, long Amount)>
             {
-                { HeroItemEnums.Wood, resource[0] },
-                { HeroItemEnums.Clay, resource[1] },
-                { HeroItemEnums.Iron, resource[2] },
-                { HeroItemEnums.Crop, resource[3] },
+                (HeroItemEnums.Wood, resource[0]),
+                (HeroItemEnums.Clay, resource[1]),
+                (HeroItemEnums.Iron, resource[2]),
+                (HeroItemEnums.Crop, resource[3]),
             };
 
-            foreach (var (item, amount) in items)
+            foreach (var (item, amount) in items.OrderBy(_ => Random.Shared.Next()))
             {
                 if (amount == 0) continue;
 

--- a/MainCore/Commands/Features/UseHeroItem/UseHeroResourceCommand.cs
+++ b/MainCore/Commands/Features/UseHeroItem/UseHeroResourceCommand.cs
@@ -39,7 +39,9 @@ namespace MainCore.Commands.Features.UseHeroItem
                 (HeroItemEnums.Crop, resource[3]),
             };
 
-            foreach (var (item, amount) in items.OrderBy(_ => Random.Shared.Next()))
+            var randomItems = items.OrderBy(_ => Random.Shared.Next()).ToList();
+
+            foreach (var (item, amount) in randomItems)
             {
                 if (amount == 0) continue;
 


### PR DESCRIPTION
## Summary
- make hero resource usage order random every time

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684e397ff0f8832f83b14ffce1074097