### PR TITLE
Ensure NPC tasks regenerate when missing

### DIFF
--- a/MainCore/Notifications/Handlers/Trigger/NpcVillageUpdateTrigger.cs
+++ b/MainCore/Notifications/Handlers/Trigger/NpcVillageUpdateTrigger.cs
@@ -1,0 +1,34 @@
+using MainCore.Constraints;
+
+namespace MainCore.Notifications.Handlers.Trigger
+{
+    [Handler]
+    public static partial class NpcVillageUpdateTrigger
+    {
+        private static async ValueTask HandleAsync(
+            IAccountVillageConstraint notification,
+            GetVillageNameQuery.Handler getVillageNameQuery,
+            ITaskManager taskManager,
+            ISettingService settingService,
+            CancellationToken cancellationToken)
+        {
+            var accountId = notification.AccountId;
+            var villageId = notification.VillageId;
+
+            var autoNpcEnable = settingService.BooleanByName(villageId, VillageSettingEnums.AutoNPCEnable);
+            if (!autoNpcEnable) return;
+
+            var hasNpcTask = taskManager
+                .GetTaskList(accountId)
+                .OfType<NpcTask.Task>()
+                .Any(x => x.VillageId == villageId);
+            if (hasNpcTask) return;
+
+            if (taskManager.IsExist<UpdateVillageTask.Task>(accountId, villageId)) return;
+
+            var villageName = await getVillageNameQuery.HandleAsync(new(villageId), cancellationToken);
+            taskManager.Add<UpdateVillageTask.Task>(new(accountId, villageId, villageName));
+        }
+    }
+}
+

--- a/MainCore/Notifications/Message/AccountInit.cs
+++ b/MainCore/Notifications/Message/AccountInit.cs
@@ -18,6 +18,7 @@ namespace MainCore.Notifications.Message
             SleepTaskTrigger.Handler sleepTaskTrigger,
             StartAdventureTaskTrigger.Handler startAdventureTaskTrigger,
             TrainTroopTaskTrigger.Handler trainTroopTaskTrigger,
+            NpcVillageUpdateTrigger.Handler npcVillageUpdateTrigger,
             UpgradeBuildingTaskTrigger.Handler upgradeBuildingTaskTrigger,
             CancellationToken cancellationToken)
         {
@@ -33,6 +34,7 @@ namespace MainCore.Notifications.Message
             {
                 await refreshVillageTaskTrigger.HandleAsync(new VillageNotification(accountId, village), cancellationToken);
                 await trainTroopTaskTrigger.HandleAsync(new VillageNotification(accountId, village), cancellationToken);
+                await npcVillageUpdateTrigger.HandleAsync(new VillageNotification(accountId, village), cancellationToken);
             }
 
             var hasBuildingJobVillages = await getHasBuildJobVillagesQuery.HandleAsync(new(accountId));


### PR DESCRIPTION
## Summary
- ensure each NPC-enabled village triggers an update when missing an NPC task
- call new `NpcVillageUpdateTrigger` during account initialization

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: libe_sqlite3 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68504aef084c832f9fae6bf792d5ed9d