### PR TITLE
Improve resource build task logic

### DIFF
--- a/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MainCore.Constraints;
 using System.Text.Json;
+using MainCore.Infrasturecture.Persistence;
 
 namespace MainCore.Commands.Features.UpgradeBuilding
 {
@@ -16,8 +17,8 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             UpdateBuildingCommand.Handler updateBuildingCommand,
             GetLayoutBuildingsQuery.Handler getLayoutBuildingsQuery,
             DeleteJobByIdCommand.Handler deleteJobByIdCommand,
-            AddJobCommand.Handler addJobCommand,
             JobUpdated.Handler jobUpdated,
+            AppDbContext context,
             CancellationToken cancellationToken
         )
         {
@@ -29,19 +30,35 @@ namespace MainCore.Commands.Features.UpgradeBuilding
             Result result;
             if (job.Type == JobTypeEnums.ResourceBuild)
             {
+                var storage = context.Storages
+                    .Where(x => x.VillageId == villageId.Value)
+                    .Select(x => new StorageDto
+                    {
+                        Wood = x.Wood,
+                        Clay = x.Clay,
+                        Iron = x.Iron,
+                        Crop = x.Crop
+                    })
+                    .FirstOrDefault() ?? new();
+
                 var layoutBuildings = await getLayoutBuildingsQuery.HandleAsync(new(villageId, true));
                 var resourceBuildPlan = JsonSerializer.Deserialize<ResourceBuildPlan>(job.Content)!;
-                var normalBuildPlan = GetNormalBuildPlan(villageId, resourceBuildPlan, layoutBuildings);
+                var normalBuildPlan = GetNormalBuildPlan(resourceBuildPlan, layoutBuildings, storage);
                 if (normalBuildPlan is null)
                 {
                     await deleteJobByIdCommand.HandleAsync(new(villageId, job.Id), cancellationToken);
+                    await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
+                    return Result.Fail<Response>(Continue.Error);
                 }
-                else
-                {
-                    await addJobCommand.HandleAsync(new(villageId, normalBuildPlan.ToJob(), true));
-                }
-                await jobUpdated.HandleAsync(new(accountId, villageId), cancellationToken);
-                return Result.Fail<Response>(Continue.Error);
+
+                var dorfIndex = normalBuildPlan.Location < 19 ? 1 : 2;
+                result = await toDorfCommand.HandleAsync(new(accountId, dorfIndex), cancellationToken);
+                if (result.IsFailed) return Result.Fail<Response>(result.Errors);
+
+                var updateBuildingCommandResult = await updateBuildingCommand.HandleAsync(new(accountId, villageId), cancellationToken);
+                if (updateBuildingCommandResult.IsFailed) return Result.Fail<Response>(updateBuildingCommandResult.Errors);
+
+                return Result.Ok(new Response(normalBuildPlan, job.Id));
             }
 
             var plan = JsonSerializer.Deserialize<NormalBuildPlan>(job.Content)!;
@@ -65,9 +82,9 @@ namespace MainCore.Commands.Features.UpgradeBuilding
         }
 
         private static NormalBuildPlan? GetNormalBuildPlan(
-            VillageId villageId,
             ResourceBuildPlan plan,
-            List<BuildingItem> layoutBuildings
+            List<BuildingItem> layoutBuildings,
+            StorageDto storage
         )
         {
             var fieldList = new Dictionary<ResourcePlanEnums, List<BuildingEnums>>()
@@ -103,27 +120,47 @@ namespace MainCore.Commands.Features.UpgradeBuilding
 
             if (layoutBuildings.Count == 0) return null;
 
-            var minLevel = layoutBuildings
-                .Select(x => x.Level)
-                .Min();
-
-            var chosenOne = layoutBuildings
-                .Where(x => x.Level == minLevel)
-                .OrderBy(x => x.Id.Value + Random.Shared.Next())
-                .FirstOrDefault();
-
-            if (chosenOne is null) return null;
-
-            // Fix: Use the highest of current, queue, and job levels for the next job
-            int nextLevel = Math.Max(Math.Max(chosenOne.CurrentLevel, chosenOne.QueueLevel), chosenOne.JobLevel) + 1;
-
-            var normalBuildPlan = new NormalBuildPlan()
+            var typeStorage = new Dictionary<BuildingEnums, long>
             {
-                Type = chosenOne.Type,
-                Level = nextLevel,
-                Location = chosenOne.Location,
+                { BuildingEnums.Woodcutter, storage.Wood },
+                { BuildingEnums.ClayPit, storage.Clay },
+                { BuildingEnums.IronMine, storage.Iron },
+                { BuildingEnums.Cropland, storage.Crop },
             };
-            return normalBuildPlan;
+
+            var orderedTypes = fieldTypes
+                .OrderBy(t => typeStorage[t])
+                .ToList();
+
+            foreach (var type in orderedTypes)
+            {
+                var candidates = layoutBuildings
+                    .Where(x => x.Type == type)
+                    .ToList();
+                if (candidates.Count == 0) continue;
+
+                var minLevel = candidates
+                    .Select(x => x.Level)
+                    .Min();
+
+                var chosenOne = candidates
+                    .Where(x => x.Level == minLevel)
+                    .OrderBy(x => x.Id.Value + Random.Shared.Next())
+                    .FirstOrDefault();
+
+                if (chosenOne is null) continue;
+
+                int nextLevel = Math.Max(Math.Max(chosenOne.CurrentLevel, chosenOne.QueueLevel), chosenOne.JobLevel) + 1;
+
+                return new NormalBuildPlan
+                {
+                    Type = chosenOne.Type,
+                    Level = nextLevel,
+                    Location = chosenOne.Location,
+                };
+            }
+
+            return null;
         }
 
         private static bool IsJobComplete(JobDto job, List<BuildingDto> buildings, List<QueueBuilding> queueBuildings)


### PR DESCRIPTION
## Summary
- compute the optimal resource field directly when a ResourceBuild job runs
- prioritize upgrading the resource type with the lowest storage amount
- stop enqueueing extra jobs for All Resources and Exclude Crop plans

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850555871c8832f8f04e144ca8227b7