### PR TITLE
Add Telegram build queue commands

### DIFF
--- a/MainCore/Queries/GetVillageIdByNameQuery.cs
+++ b/MainCore/Queries/GetVillageIdByNameQuery.cs
@@ -1,0 +1,28 @@
+using MainCore.Constraints;
+
+namespace MainCore.Queries
+{
+    [Handler]
+    public static partial class GetVillageIdByNameQuery
+    {
+        public sealed record Query(AccountId AccountId, string Name) : IAccountQuery;
+
+        private static async ValueTask<VillageId?> HandleAsync(
+            Query query,
+            AppDbContext context,
+            CancellationToken cancellationToken
+            )
+        {
+            await Task.CompletedTask;
+            var (accountId, name) = query;
+
+            var id = context.Villages
+                .Where(x => x.AccountId == accountId.Value)
+                .Where(x => x.Name == name)
+                .Select(x => x.Id)
+                .FirstOrDefault();
+            if (id == 0) return null;
+            return new VillageId(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend TelegramCommandService to support `build` operations
  - listing village build jobs
  - pausing/resuming building for a village
  - removing and adding build orders
- wire parsing for new commands

## Testing
- `dotnet build MainCore/MainCore.csproj --no-restore`
- `dotnet test MainCore.Test/MainCore.Test.csproj --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6850635c392c832f9307787e8666f92c