### PR TITLE
Update telegram tasks list date format

### DIFF
--- a/MainCore/Services/TelegramCommandService.cs
+++ b/MainCore/Services/TelegramCommandService.cs
@@ -143,7 +143,7 @@ namespace MainCore.Services
             sb.AppendLine("Task\tExecute at\tStage");
             foreach (var task in tasks)
             {
-                sb.AppendLine($"{task.Description}\t{task.ExecuteAt:yyyy-MM-dd HH:mm:ss}\t{task.Stage}");
+                sb.AppendLine($"{task.Description}\t{task.ExecuteAt:MM-dd HH:mm:ss}\t{task.Stage}");
             }
 
             await _telegramService.SendText(sb.ToString(), accountId);


### PR DESCRIPTION
## Summary
- tweak `SendTasks` output to omit year from timestamps

## Testing
- `dotnet test MainCore.Test/MainCore.Test.csproj --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3b8dbd0832fa68ce9d0f175b4d7