### PR TITLE
Trigger building upgrade after NPC trade

### DIFF
--- a/MainCore/Tasks/NPCTask.cs
+++ b/MainCore/Tasks/NPCTask.cs
@@ -1,4 +1,5 @@
 ﻿using MainCore.Commands.Features.NpcResource;
+using MainCore.Notifications.Handlers.Trigger;
 using MainCore.Tasks.Base;
 
 namespace MainCore.Tasks
@@ -20,6 +21,7 @@ namespace MainCore.Tasks
             ToNpcResourcePageCommand.Handler toNpcResourcePageCommand,
             NpcResourceCommand.Handler npcResourceCommand,
             UpdateStorageCommand.Handler updateStorageCommand, // <-- Inject
+            UpgradeBuildingTaskTrigger.Handler upgradeBuildingTaskTrigger,
             CancellationToken cancellationToken)
         {
             Result result;
@@ -29,6 +31,9 @@ namespace MainCore.Tasks
             if (result.IsFailed) return result;
             // Update storage after NPC trade
             await updateStorageCommand.HandleAsync(new(task.AccountId, task.VillageId), cancellationToken);
+
+            await upgradeBuildingTaskTrigger.HandleAsync(task, cancellationToken);
+
             return Result.Ok();
         }
     }

--- a/README.md
+++ b/README.md
@@ -10,4 +10,8 @@ Improving original code.
 When the **NPC Crop exchange** option is enabled the bot now predicts when the granary will reach the configured `AutoNPCGranaryPercent`.  Using the stored crop production and current storage values an `NpcTask` is scheduled for that time in the task list, ensuring NPC trades happen right before the granary overflows.
 The trigger re-evaluates this schedule each time resource or production data is updated so existing NPC tasks automatically shift to the new predicted time.
 
+## Post NPC upgrade check
+
+After an NPC trade completes successfully the bot immediately triggers an upgrade building check.  Since resources have been redistributed an upgrade might now be affordable, so the building queue is evaluated again.
+
 


### PR DESCRIPTION
## Summary
- trigger `UpgradeBuildingTask` when an NPC trade completes
- document new behavior in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851aa106690832f90ee2573239273c6