### PR TITLE
Add adventure travel time limit setting

### DIFF
--- a/MainCore.Test/Parsers/AdventureParser.Test.cs
+++ b/MainCore.Test/Parsers/AdventureParser.Test.cs
@@ -69,5 +69,25 @@ namespace MainCore.Test.Parsers
             actual.ShouldNotContain("unknown");
             actual.ShouldNotContain("[~|~]");
         }
+
+        [Fact]
+        public void GetAdventureTravelTime()
+        {
+            _html.Load(AdventuresPage);
+            var adventureButton = MainCore.Parsers.AdventureParser.GetAdventureButton(_html);
+            adventureButton.ShouldNotBeNull();
+            var travelTime = MainCore.Parsers.AdventureParser.GetAdventureTravelTime(adventureButton.ParentNode.ParentNode);
+            travelTime.ShouldBeLessThan(TimeSpan.FromMinutes(10));
+        }
+
+        [Fact]
+        public void GetAdventureButtonWithMaxTime()
+        {
+            _html.Load(AdventuresPage);
+            var button = MainCore.Parsers.AdventureParser.GetAdventureButton(_html, TimeSpan.FromMinutes(10));
+            button.ShouldNotBeNull();
+            var none = MainCore.Parsers.AdventureParser.GetAdventureButton(_html, TimeSpan.FromMinutes(5));
+            none.ShouldBeNull();
+        }
     }
 }

--- a/MainCore/Commands/Features/StartAdventure/ExploreAdventureCommand.cs
+++ b/MainCore/Commands/Features/StartAdventure/ExploreAdventureCommand.cs
@@ -1,4 +1,6 @@
 ﻿using MainCore.Constraints;
+using MainCore.Services;
+using System;
 
 namespace MainCore.Commands.Features.StartAdventure
 {
@@ -11,14 +13,16 @@ namespace MainCore.Commands.Features.StartAdventure
             Command command,
             IChromeBrowser browser,
             ILogger logger,
+            ISettingService settingService,
             CancellationToken cancellationToken)
         {
             var html = browser.Html;
 
             if (!AdventureParser.CanStartAdventure(html)) return Skip.NoAdventure;
 
-            var adventureButton = AdventureParser.GetAdventureButton(html);
-            if (adventureButton is null) return Retry.ButtonNotFound("adventure");
+            var maxMinutes = settingService.ByName(command.AccountId, AccountSettingEnums.AdventureMaxTravelTime);
+            var adventureButton = AdventureParser.GetAdventureButton(html, TimeSpan.FromMinutes(maxMinutes));
+            if (adventureButton is null) return Skip.NoAdventure;
             logger.Information("Start adventure {Adventure}", AdventureParser.GetAdventureInfo(adventureButton));
 
             static bool ContinueShow(IWebDriver driver)

--- a/MainCore/Enums/AccountSettingEnums.cs
+++ b/MainCore/Enums/AccountSettingEnums.cs
@@ -17,6 +17,7 @@
         SleepTimeMax,
         HeadlessChrome,
         EnableAutoStartAdventure,
+        AdventureMaxTravelTime,
         EnableTelegramMessage,
     }
 }

--- a/MainCore/Infrasturecture/Persistence/AppDbContext.cs
+++ b/MainCore/Infrasturecture/Persistence/AppDbContext.cs
@@ -48,6 +48,7 @@ namespace MainCore.Infrasturecture.Persistence
             {AccountSettingEnums.WorkTimeMax, 720 },
             {AccountSettingEnums.HeadlessChrome, 0 },
             {AccountSettingEnums.EnableAutoStartAdventure, 0 },
+            {AccountSettingEnums.AdventureMaxTravelTime, 90 },
             {AccountSettingEnums.EnableTelegramMessage, 0 },
         }.ToImmutableDictionary();
 

--- a/MainCore/Parsers/AdventureParser.cs
+++ b/MainCore/Parsers/AdventureParser.cs
@@ -48,7 +48,7 @@
             return adventureAvailabe;
         }
 
-        public static HtmlNode? GetAdventureButton(HtmlDocument doc)
+        public static HtmlNode? GetAdventureButton(HtmlDocument doc, TimeSpan? maxTravelTime = null)
         {
             var adventureTable = doc.GetElementbyId("heroAdventure");
             if (adventureTable is null) return null;
@@ -58,15 +58,29 @@
                 .FirstOrDefault();
             if (adventureTableBody is null) return null;
 
-            var adventureTableBodyRow = adventureTableBody
-                .Descendants("tr")
-                .FirstOrDefault();
-            if (adventureTableBodyRow is null) return null;
+            foreach (var adventureTableBodyRow in adventureTableBody.Descendants("tr"))
+            {
+                if (maxTravelTime is not null)
+                {
+                    var travelTime = GetAdventureTravelTime(adventureTableBodyRow);
+                    if (travelTime > maxTravelTime) continue;
+                }
 
-            var startAdventureButton = adventureTableBodyRow
-                .Descendants("button")
-                .FirstOrDefault();
-            return startAdventureButton;
+                var startAdventureButton = adventureTableBodyRow
+                    .Descendants("button")
+                    .FirstOrDefault();
+                if (startAdventureButton is not null) return startAdventureButton;
+            }
+
+            return null;
+        }
+
+        public static TimeSpan GetAdventureTravelTime(HtmlNode node)
+        {
+            var tdList = node.Descendants("td").ToArray();
+            if (tdList.Length < 3) return TimeSpan.MaxValue;
+            var durationText = tdList[2].InnerText.Trim();
+            return TimeSpan.TryParse(durationText, out var result) ? result : TimeSpan.MaxValue;
         }
 
         public static HtmlNode? GetContinueButton(HtmlDocument doc)

--- a/MainCore/UI/Models/Input/AccountSettingInput.cs
+++ b/MainCore/UI/Models/Input/AccountSettingInput.cs
@@ -15,6 +15,7 @@ namespace MainCore.UI.Models.Input
             EnableAutoLoadVillage = settings.GetValueOrDefault(AccountSettingEnums.EnableAutoLoadVillageBuilding) == 1;
             HeadlessChrome = settings.GetValueOrDefault(AccountSettingEnums.HeadlessChrome) == 1;
             EnableAutoStartAdventure = settings.GetValueOrDefault(AccountSettingEnums.EnableAutoStartAdventure) == 1;
+            AdventureMaxTravelTime = settings.GetValueOrDefault(AccountSettingEnums.AdventureMaxTravelTime);
             EnableTelegramMessage = settings.GetValueOrDefault(AccountSettingEnums.EnableTelegramMessage) == 1;
             FarmInterval.Set(settings.GetValueOrDefault(AccountSettingEnums.FarmIntervalMin), settings.GetValueOrDefault(AccountSettingEnums.FarmIntervalMax));
             UseStartAllButton = settings.GetValueOrDefault(AccountSettingEnums.UseStartAllButton) == 1;
@@ -54,6 +55,7 @@ namespace MainCore.UI.Models.Input
 
                 { AccountSettingEnums.HeadlessChrome, headlessChrome },
                 { AccountSettingEnums.EnableAutoStartAdventure, autoStartAdventure },
+                { AccountSettingEnums.AdventureMaxTravelTime, AdventureMaxTravelTime },
                 { AccountSettingEnums.EnableTelegramMessage, EnableTelegramMessage ? 1 : 0 },
             };
             return settings;
@@ -75,6 +77,9 @@ namespace MainCore.UI.Models.Input
 
         [Reactive]
         private bool _enableAutoStartAdventure;
+
+        [Reactive]
+        private int _adventureMaxTravelTime = 90;
 
         [Reactive]
         private bool _enableTelegramMessage;

--- a/WPFUI/Views/Tabs/AccountSettingTab.xaml
+++ b/WPFUI/Views/Tabs/AccountSettingTab.xaml
@@ -56,7 +56,11 @@
                     <StackPanel>
                         <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="Feature settings" VerticalAlignment="Center" FontWeight="Bold" />
                         <CheckBox x:Name="EnableAutoLoadVillage" Content="Enable auto load village's building" />
-                        <CheckBox x:Name="EnableAutoStartAdventure" Content="Enable auto start adventure" />
+                        <StackPanel Orientation="Horizontal">
+                            <CheckBox x:Name="EnableAutoStartAdventure" Content="Enable auto start adventure" />
+                            <TextBox x:Name="AdventureMaxTravelTime" Width="40" Margin="5,0,0,0" />
+                            <Label Content=" mins" />
+                        </StackPanel>
                         <CheckBox x:Name="EnableTelegramMessage" Content="Enable msg system" />
                         <TextBox x:Name="BotToken" materialDesign:HintAssist.Hint="Bot token" Style="{DynamicResource MaterialDesignFloatingHintTextBox}" />
                         <TextBox x:Name="ChatId" materialDesign:HintAssist.Hint="Chat id" Style="{DynamicResource MaterialDesignFloatingHintTextBox}" />

--- a/WPFUI/Views/Tabs/AccountSettingTab.xaml.cs
+++ b/WPFUI/Views/Tabs/AccountSettingTab.xaml.cs
@@ -30,6 +30,7 @@ namespace WPFUI.Views.Tabs
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.Tribe, v => v.Tribes.ViewModel).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.HeadlessChrome, v => v.HeadlessChrome.IsChecked).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.EnableAutoStartAdventure, v => v.EnableAutoStartAdventure.IsChecked).DisposeWith(d);
+                this.Bind(ViewModel, vm => vm.AccountSettingInput.AdventureMaxTravelTime, v => v.AdventureMaxTravelTime.Text).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.EnableTelegramMessage, v => v.EnableTelegramMessage.IsChecked).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.TelegramSettingInput.BotToken, v => v.BotToken.Text).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.TelegramSettingInput.ChatId, v => v.ChatId.Text).DisposeWith(d);


### PR DESCRIPTION
## Summary
- add `AdventureMaxTravelTime` option to account settings with default 90 minutes
- expose travel time limit input in account settings UI
- filter adventures by travel time in `ExploreAdventureCommand`
- extend `AdventureParser` to parse travel time and handle limits
- update parser tests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b1896758832fb6bc61e373c73150