### PR TITLE
Wait for storage upgrade

### DIFF
--- a/MainCore/Errors/Skip.cs
+++ b/MainCore/Errors/Skip.cs
@@ -11,6 +11,7 @@
         public static Skip BuildingJobQueueBroken => new("Building job queue is broken. No building in construct but cannot choose job");
         public static Skip NotEnoughResource => new("Reschedule becasue doesn't have enough resource");
         public static Skip ConstructionQueueFull => new("Construction queue is full");
+        public static Skip WaitingStorageUpgrade => new("Waiting for storage upgrade to finish");
         public static Skip AccountLogout => new("Account is logout. Re-login now");
 
         public static Skip NoRallypoint => new("No rallypoint found. Recheck & load village has rallypoint in Village>Build tab");

--- a/MainCore/Queries/GetQueueBuildingByTypeQuery.cs
+++ b/MainCore/Queries/GetQueueBuildingByTypeQuery.cs
@@ -1,0 +1,29 @@
+using MainCore.Constraints;
+using MainCore.Entities;
+using MainCore.Enums;
+
+namespace MainCore.Queries
+{
+    [Handler]
+    public static partial class GetQueueBuildingByTypeQuery
+    {
+        public sealed record Query(VillageId VillageId, BuildingEnums BuildingType) : IVillageQuery;
+
+        private static async ValueTask<QueueBuilding?> HandleAsync(
+            Query query,
+            AppDbContext context,
+            CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            var (villageId, buildingType) = query;
+
+            var queueBuilding = context.QueueBuildings
+               .Where(x => x.VillageId == villageId.Value)
+               .Where(x => x.Type == buildingType)
+               .OrderBy(x => x.Position)
+               .FirstOrDefault();
+
+            return queueBuilding;
+        }
+    }
+}

--- a/MainCore/Tasks/UpgradeBuildingTask.cs
+++ b/MainCore/Tasks/UpgradeBuildingTask.cs
@@ -69,6 +69,15 @@ namespace MainCore.Tasks
                     if (result.HasError<Skip>())
                     {
                         var time = UpgradeParser.GetTimeWhenEnoughResource(browser.Html, plan.Type);
+                        if (result.Errors.OfType<Skip>().Any(x => x.Message == Skip.WaitingStorageUpgrade.Message))
+                        {
+                            var buildingQueue = await getFirstQueueBuildingQuery.HandleAsync(new(task.VillageId), cancellationToken);
+                            if (buildingQueue != null)
+                            {
+                                time = buildingQueue.CompleteTime - DateTime.Now + TimeSpan.FromSeconds(3);
+                                if (time < TimeSpan.Zero) time = TimeSpan.Zero;
+                            }
+                        }
                         task.ExecuteAt = DateTime.Now.Add(time);
                         logger.Information("Not enough resource. Schedule next run at {Time}", task.ExecuteAt.ToString("yyyy-MM-dd HH:mm:ss"));
                     }


### PR DESCRIPTION
## Summary
- add a new `WaitingStorageUpgrade` skip code to signal waiting for bigger storage
- when storage capacity is insufficient and warehouse/granary upgrade is queued, return the new skip code instead of looping
- reschedule build task based on queue time when waiting for storage upgrade
- add helper query to fetch queue buildings by type

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685283355624832f859d57cbeac3a3d4