### PR TITLE
Add attack tab and crash logging

### DIFF
--- a/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
+++ b/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
@@ -49,7 +49,7 @@ namespace MainCore.Commands.UI.Villages.AttackViewModel
             var sb = new System.Text.StringBuilder();
             sb.AppendLine($"document.getElementsByName('x')[0].value='{plan.X}';");
             sb.AppendLine($"document.getElementsByName('y')[0].value='{plan.Y}';");
-            sb.AppendLine($"var et=document.querySelector('input[name=\"eventType\"][value=\"{(int)plan.Type}\"]');if(et)et.checked=true;");
+            sb.AppendLine($"var et=document.querySelector(\"input[name='eventType'][value='{(int)plan.Type}']\");if(et)et.checked=true;");
             for (int i = 0; i < plan.Troops.Length; i++)
             {
                 var value = plan.Troops[i];

--- a/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
+++ b/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
@@ -32,7 +32,9 @@ namespace MainCore.Commands.UI.Villages.AttackViewModel
             result = await toBuildingCommand.HandleAsync(new(accountId, location), cancellationToken);
             if (result.IsFailed) return result;
 
-            result = await switchTabCommand.HandleAsync(new(accountId, 1), cancellationToken);
+            // Open the send troops tab in the rally point
+            // Tab index 2 corresponds to the "Send troops" tab
+            result = await switchTabCommand.HandleAsync(new(accountId, 2), cancellationToken);
             if (result.IsFailed) return result;
 
             var script = BuildScript(plan);

--- a/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
+++ b/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
@@ -52,7 +52,10 @@ namespace MainCore.Commands.UI.Villages.AttackViewModel
             result = await browser.Click(By.Id("confirmSendTroops"));
             if (result.IsFailed) return result;
 
-            result = await browser.WaitPageChanged("dorf", cancellationToken);
+            // After confirming the attack Travian returns to the rally point
+            // page. Waiting for a generic page reload is enough here since the
+            // URL usually stays on build.php.
+            result = await browser.WaitPageLoaded(cancellationToken);
             if (result.IsFailed) return result;
 
             return Result.Ok();

--- a/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
+++ b/MainCore/Commands/UI/Villages/AttackViewModel/SendAttackCommand.cs
@@ -1,0 +1,61 @@
+using MainCore.Constraints;
+using MainCore.Models;
+
+namespace MainCore.Commands.UI.Villages.AttackViewModel
+{
+    [Handler]
+    public static partial class SendAttackCommand
+    {
+        public sealed record Command(AccountId AccountId, VillageId VillageId, AttackPlan Plan) : IAccountVillageCommand;
+
+        private static async ValueTask<Result> HandleAsync(
+            Command command,
+            IChromeBrowser browser,
+            ToDorfCommand.Handler toDorfCommand,
+            UpdateBuildingCommand.Handler updateBuildingCommand,
+            ToBuildingCommand.Handler toBuildingCommand,
+            SwitchTabCommand.Handler switchTabCommand,
+            CancellationToken cancellationToken)
+        {
+            var (accountId, villageId, plan) = command;
+
+            Result result;
+            result = await toDorfCommand.HandleAsync(new(accountId, 2), cancellationToken);
+            if (result.IsFailed) return result;
+
+            var (_, isFailed, response, errors) = await updateBuildingCommand.HandleAsync(new(accountId, villageId), cancellationToken);
+            if (isFailed) return Result.Fail(errors);
+
+            var location = response.Buildings.FirstOrDefault(x => x.Type == BuildingEnums.RallyPoint)?.Location ?? 0;
+            if (location == 0) return Skip.NoRallypoint;
+
+            result = await toBuildingCommand.HandleAsync(new(accountId, location), cancellationToken);
+            if (result.IsFailed) return result;
+
+            result = await switchTabCommand.HandleAsync(new(accountId, 1), cancellationToken);
+            if (result.IsFailed) return result;
+
+            var script = BuildScript(plan);
+            result = await browser.ExecuteJsScript(script);
+            if (result.IsFailed) return result;
+
+            return Result.Ok();
+        }
+
+        private static string BuildScript(AttackPlan plan)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"document.getElementsByName('x')[0].value='{plan.X}';");
+            sb.AppendLine($"document.getElementsByName('y')[0].value='{plan.Y}';");
+            sb.AppendLine($"var et=document.querySelector('input[name=\"eventType\"][value=\"{(int)plan.Type}\"]');if(et)et.checked=true;");
+            for (int i = 0; i < plan.Troops.Length; i++)
+            {
+                var value = plan.Troops[i];
+                if (value <= 0) continue;
+                sb.AppendLine($"var input=document.getElementsByName('troop[t{i + 1}]')[0];if(input){{input.value='{value}';}}");
+            }
+            sb.AppendLine("document.querySelector('button[type=submit]').click();");
+            return sb.ToString();
+        }
+    }
+}

--- a/MainCore/Enums/AttackTypeEnums.cs
+++ b/MainCore/Enums/AttackTypeEnums.cs
@@ -1,0 +1,21 @@
+namespace MainCore.Enums
+{
+    public enum AttackTypeEnums
+    {
+        /// <summary>
+        /// Send troops as reinforcement. This corresponds to value="5" on the
+        /// rally point send troops page.
+        /// </summary>
+        Reinforcement = 5,
+
+        /// <summary>
+        /// Normal attack. This corresponds to value="3".
+        /// </summary>
+        Attack = 3,
+
+        /// <summary>
+        /// Raid attack. This corresponds to value="4".
+        /// </summary>
+        Raid = 4,
+    }
+}

--- a/MainCore/Models/AttackPlan.cs
+++ b/MainCore/Models/AttackPlan.cs
@@ -1,0 +1,12 @@
+using MainCore.Enums;
+
+namespace MainCore.Models
+{
+    public class AttackPlan
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public AttackTypeEnums Type { get; set; }
+        public int[] Troops { get; set; } = Array.Empty<int>();
+    }
+}

--- a/MainCore/UI/Models/Input/AttackInput.cs
+++ b/MainCore/UI/Models/Input/AttackInput.cs
@@ -1,0 +1,27 @@
+using MainCore.Enums;
+using MainCore.UI.ViewModels.Abstract;
+using MainCore.UI.ViewModels.UserControls;
+
+namespace MainCore.UI.Models.Input
+{
+    public partial class AttackInput : ViewModelBase
+    {
+        public AmountInputViewModel[] Troops { get; } = Enumerable.Range(0, 11)
+            .Select(_ => new AmountInputViewModel()).ToArray();
+
+        [Reactive]
+        private int _x;
+
+        [Reactive]
+        private int _y;
+
+        [Reactive]
+        private AttackTypeEnums _attackType = AttackTypeEnums.Raid;
+
+        public (int x, int y, AttackTypeEnums type, int[] troops) Get()
+        {
+            var troopValues = Troops.Select(t => t.Get()).ToArray();
+            return (X, Y, AttackType, troopValues);
+        }
+    }
+}

--- a/MainCore/UI/Stores/VillageTabStore.cs
+++ b/MainCore/UI/Stores/VillageTabStore.cs
@@ -17,15 +17,17 @@ namespace MainCore.UI.Stores
 
         private readonly NoVillageViewModel _noVillageViewModel;
         private readonly VillageSettingViewModel _villageSettingViewModel;
+        private readonly AttackViewModel _attackViewModel;
         private readonly BuildViewModel _buildViewModel;
         private readonly InfoViewModel _infoViewModel;
 
-        public VillageTabStore(NoVillageViewModel noVillageViewModel, InfoViewModel infoViewModel, BuildViewModel buildViewModel, VillageSettingViewModel villageSettingViewModel)
+        public VillageTabStore(NoVillageViewModel noVillageViewModel, InfoViewModel infoViewModel, BuildViewModel buildViewModel, VillageSettingViewModel villageSettingViewModel, AttackViewModel attackViewModel)
         {
             _noVillageViewModel = noVillageViewModel;
             _buildViewModel = buildViewModel;
             _infoViewModel = infoViewModel;
             _villageSettingViewModel = villageSettingViewModel;
+            _attackViewModel = attackViewModel;
         }
 
         public void SetTabType(VillageTabType tabType)
@@ -50,6 +52,7 @@ namespace MainCore.UI.Stores
 
                 case VillageTabType.Normal:
                     _buildViewModel.IsActive = true;
+                    _attackViewModel.IsActive = true;
                     break;
 
                 default:
@@ -61,5 +64,6 @@ namespace MainCore.UI.Stores
         public BuildViewModel BuildViewModel => _buildViewModel;
         public VillageSettingViewModel VillageSettingViewModel => _villageSettingViewModel;
         public InfoViewModel InfoViewModel => _infoViewModel;
+        public AttackViewModel AttackViewModel => _attackViewModel;
     }
 }

--- a/MainCore/UI/ViewModels/Tabs/Villages/AttackViewModel.cs
+++ b/MainCore/UI/ViewModels/Tabs/Villages/AttackViewModel.cs
@@ -1,0 +1,47 @@
+using MainCore.Commands.UI.Villages.AttackViewModel;
+using MainCore.Models;
+using MainCore.UI.Models.Input;
+using MainCore.UI.Models.Output;
+using MainCore.UI.ViewModels.Abstract;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MainCore.UI.ViewModels.Tabs.Villages
+{
+    [RegisterSingleton<AttackViewModel>]
+    public partial class AttackViewModel : VillageTabViewModelBase
+    {
+        public AttackInput AttackInput { get; } = new();
+        private readonly IDialogService _dialogService;
+        private readonly ICustomServiceScopeFactory _serviceScopeFactory;
+
+        public AttackViewModel(IDialogService dialogService, ICustomServiceScopeFactory serviceScopeFactory)
+        {
+            _dialogService = dialogService;
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+
+        [ReactiveCommand]
+        private async Task Send()
+        {
+            using var scope = _serviceScopeFactory.CreateScope(AccountId);
+            var handler = scope.ServiceProvider.GetRequiredService<SendAttackCommand.Handler>();
+            var (x, y, type, troops) = AttackInput.Get();
+            var plan = new AttackPlan { X = x, Y = y, Type = type, Troops = troops };
+            var result = await handler.HandleAsync(new(AccountId, VillageId, plan));
+            if (result.IsFailed)
+            {
+                await _dialogService.MessageBox.Handle(new MessageBoxData("Error", result.ToString()));
+            }
+            else
+            {
+                await _dialogService.MessageBox.Handle(new MessageBoxData("Information", "Attack sent"));
+            }
+        }
+
+        protected override Task Load(VillageId villageId)
+        {
+            // no async load for now
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WPFUI/App.xaml.cs
+++ b/WPFUI/App.xaml.cs
@@ -8,6 +8,7 @@ using ReactiveMarbles.Extensions.Hosting.Wpf;
 using ReactiveUI;
 using Splat.ModeDetection;
 using System;
+using System.IO;
 using System.Reactive;
 using System.Threading.Tasks;
 using System.Windows;
@@ -22,6 +23,12 @@ namespace WPFUI
     {
         public App()
         {
+            AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
+            {
+                var ex = (Exception)args.ExceptionObject;
+                File.WriteAllText("crash.log", ex.ToString());
+            };
+
             Splat.ModeDetector.OverrideModeDetector(Mode.Run);
             var host = AppMixins.GetHostBuilder()
                 .ConfigureWpf(wpfBuilder => wpfBuilder.UseCurrentApplication(this).UseWindow<MainWindow>())

--- a/WPFUI/Views/Tabs/VillageTab.xaml
+++ b/WPFUI/Views/Tabs/VillageTab.xaml
@@ -34,6 +34,9 @@
                 <TabItem x:Name="BuildTab" Header="Build">
                     <v_tab:BuildTab x:Name="Build" />
                 </TabItem>
+                <TabItem x:Name="AttackTab" Header="Attacks">
+                    <v_tab:AttackTab x:Name="Attack" />
+                </TabItem>
                 <TabItem x:Name="SettingsTab" Header="Settings">
                     <v_tab:VillageSettingTab x:Name="Settings" />
                 </TabItem>

--- a/WPFUI/Views/Tabs/VillageTab.xaml.cs
+++ b/WPFUI/Views/Tabs/VillageTab.xaml.cs
@@ -28,18 +28,21 @@ namespace WPFUI.Views.Tabs
                 // tabs
                 this.OneWayBind(ViewModel, vm => vm.VillageTabStore.NoVillageViewModel, v => v.NoVillage.ViewModel).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageTabStore.BuildViewModel, v => v.Build.ViewModel).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.VillageTabStore.AttackViewModel, v => v.Attack.ViewModel).DisposeWith(d);
                 //this.OneWayBind(ViewModel, vm => vm.VillageTabStore.InfoViewModel, v => v.Info.ViewModel).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageTabStore.VillageSettingViewModel, v => v.Settings.ViewModel).DisposeWith(d);
 
                 // visible
                 this.OneWayBind(ViewModel, vm => vm.VillageTabStore.IsNoVillageTabVisible, v => v.NoVillageTab.Visibility).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageTabStore.IsNormalTabVisible, v => v.BuildTab.Visibility).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.VillageTabStore.IsNormalTabVisible, v => v.AttackTab.Visibility).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageTabStore.IsNormalTabVisible, v => v.SettingsTab.Visibility).DisposeWith(d);
                 //this.OneWayBind(ViewModel, vm => vm.VillageTabStore.IsNormalTabVisible, v => v.InfoTab.Visibility).DisposeWith(d);
 
                 // selected
                 this.Bind(ViewModel, vm => vm.VillageTabStore.NoVillageViewModel.IsActive, v => v.NoVillageTab.IsSelected).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.VillageTabStore.BuildViewModel.IsActive, v => v.BuildTab.IsSelected).DisposeWith(d);
+                this.Bind(ViewModel, vm => vm.VillageTabStore.AttackViewModel.IsActive, v => v.AttackTab.IsSelected).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.VillageTabStore.VillageSettingViewModel.IsActive, v => v.SettingsTab.IsSelected).DisposeWith(d);
                 //this.Bind(ViewModel, vm => vm.VillageTabStore.InfoViewModel.IsActive, v => v.InfoTab.IsSelected).DisposeWith(d);
             });

--- a/WPFUI/Views/Tabs/Villages/AttackTab.xaml
+++ b/WPFUI/Views/Tabs/Villages/AttackTab.xaml
@@ -1,0 +1,52 @@
+<v:AttackTabBase
+    x:Class="WPFUI.Views.Tabs.Villages.AttackTab"
+    xmlns:v="clr-namespace:WPFUI.Views.Tabs.Villages"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:uc="clr-namespace:WPFUI.Views.UserControls"
+    xmlns:enums="clr-namespace:MainCore.Enums;assembly=MainCore"
+    mc:Ignorable="d"
+    d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="5">
+            <Label Content="X" VerticalAlignment="Center" />
+            <TextBox x:Name="XInput" Width="50" Margin="5,0" />
+            <Label Content="Y" VerticalAlignment="Center" />
+            <TextBox x:Name="YInput" Width="50" Margin="5,0" />
+    <ComboBox x:Name="AttackType" Width="100" Margin="10,0" SelectedValuePath="Tag">
+        <ComboBoxItem Content="Reinforce" Tag="{x:Static enums:AttackTypeEnums.Reinforcement}" />
+        <ComboBoxItem Content="Raid" Tag="{x:Static enums:AttackTypeEnums.Raid}" />
+        <ComboBoxItem Content="Attack" Tag="{x:Static enums:AttackTypeEnums.Attack}" />
+    </ComboBox>
+            <Button x:Name="SendButton" Content="Send" Margin="10,0" />
+        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <WrapPanel Grid.ColumnSpan="4">
+                <uc:AmountInputUc x:Name="T1" Text="T1" Unit="" />
+                <uc:AmountInputUc x:Name="T2" Text="T2" Unit="" />
+                <uc:AmountInputUc x:Name="T3" Text="T3" Unit="" />
+                <uc:AmountInputUc x:Name="T4" Text="T4" Unit="" />
+                <uc:AmountInputUc x:Name="T5" Text="T5" Unit="" />
+                <uc:AmountInputUc x:Name="T6" Text="T6" Unit="" />
+                <uc:AmountInputUc x:Name="T7" Text="T7" Unit="" />
+                <uc:AmountInputUc x:Name="T8" Text="T8" Unit="" />
+                <uc:AmountInputUc x:Name="T9" Text="T9" Unit="" />
+                <uc:AmountInputUc x:Name="T10" Text="T10" Unit="" />
+                <uc:AmountInputUc x:Name="T11" Text="T11" Unit="" />
+            </WrapPanel>
+        </Grid>
+    </Grid>
+</v:AttackTabBase>

--- a/WPFUI/Views/Tabs/Villages/AttackTab.xaml.cs
+++ b/WPFUI/Views/Tabs/Villages/AttackTab.xaml.cs
@@ -1,0 +1,49 @@
+using MainCore.UI.ViewModels.Tabs.Villages;
+using ReactiveUI;
+using System.Reactive.Disposables;
+
+namespace WPFUI.Views.Tabs.Villages
+{
+    public class AttackTabBase : ReactiveUserControl<AttackViewModel>
+    {
+    }
+
+    public partial class AttackTab : AttackTabBase
+    {
+        public AttackTab()
+        {
+            InitializeComponent();
+            this.WhenActivated(d =>
+            {
+                this.Bind(ViewModel,
+                        vm => vm.AttackInput.X,
+                        v => v.XInput.Text,
+                        x => x.ToString(),
+                        s => int.TryParse(s, out var value) ? value : 0)
+                    .DisposeWith(d);
+                this.Bind(ViewModel,
+                        vm => vm.AttackInput.Y,
+                        v => v.YInput.Text,
+                        y => y.ToString(),
+                        s => int.TryParse(s, out var value) ? value : 0)
+                    .DisposeWith(d);
+                this.Bind(ViewModel, vm => vm.AttackInput.AttackType, v => v.AttackType.SelectedValue).DisposeWith(d);
+
+                var troops = ViewModel.AttackInput.Troops;
+                T1.ViewModel = troops[0];
+                T2.ViewModel = troops[1];
+                T3.ViewModel = troops[2];
+                T4.ViewModel = troops[3];
+                T5.ViewModel = troops[4];
+                T6.ViewModel = troops[5];
+                T7.ViewModel = troops[6];
+                T8.ViewModel = troops[7];
+                T9.ViewModel = troops[8];
+                T10.ViewModel = troops[9];
+                T11.ViewModel = troops[10];
+
+                this.BindCommand(ViewModel, vm => vm.SendCommand, v => v.SendButton).DisposeWith(d);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement attack tab UI with troop inputs and attack type selector
- add global crash logging
- generate attack automation script with better string builder
- fix query selector quoting for attack type

## Testing
- ❌ `dotnet build MainCore/MainCore.csproj -c Release` *(failed: dotnet not found)*
- ❌ `dotnet build TravBotSharp.sln -c Release -p:EnableWindowsTargeting=true` *(failed: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bbea6344832f9589ff18820495c5