### PR TITLE
Add timed attack confirmation

### DIFF
--- a/MainCore/Tasks/AttackTask.cs
+++ b/MainCore/Tasks/AttackTask.cs
@@ -9,14 +9,17 @@ namespace MainCore.Tasks
     {
         public sealed class Task : VillageTask
         {
-            public Task(AccountId accountId, VillageId villageId, string villageName, AttackPlan plan) : base(accountId, villageId, villageName)
+            public Task(AccountId accountId, VillageId villageId, string villageName, AttackPlan plan, DateTime confirmAt) : base(accountId, villageId, villageName)
             {
                 Plan = plan;
+                ConfirmAt = confirmAt;
             }
 
             protected override string TaskName => "Send attack";
 
             public AttackPlan Plan { get; }
+
+            public DateTime ConfirmAt { get; }
         }
 
         private static async ValueTask<Result> HandleAsync(
@@ -24,7 +27,7 @@ namespace MainCore.Tasks
             SendAttackCommand.Handler sendAttackCommand,
             CancellationToken cancellationToken)
         {
-            var result = await sendAttackCommand.HandleAsync(new(task.AccountId, task.VillageId, task.Plan), cancellationToken);
+            var result = await sendAttackCommand.HandleAsync(new(task.AccountId, task.VillageId, task.Plan, task.ConfirmAt), cancellationToken);
             return result;
         }
     }

--- a/MainCore/UI/Models/Input/AttackInput.cs
+++ b/MainCore/UI/Models/Input/AttackInput.cs
@@ -19,12 +19,16 @@ namespace MainCore.UI.Models.Input
         private AttackTypeEnums _attackType = AttackTypeEnums.Raid;
 
         [Reactive]
-        private DateTime _executeAt = DateTime.Now;
+        private DateTime _executeDate = DateTime.Today;
+
+        [Reactive]
+        private DateTime _executeTime = DateTime.Now;
 
         public (int x, int y, AttackTypeEnums type, int[] troops, DateTime executeAt) Get()
         {
             var troopValues = Troops.Select(t => t.Get()).ToArray();
-            return (X, Y, AttackType, troopValues, ExecuteAt);
+            var executeAt = ExecuteDate.Date.Add(ExecuteTime.TimeOfDay);
+            return (X, Y, AttackType, troopValues, executeAt);
         }
     }
 }

--- a/MainCore/UI/ViewModels/Tabs/Villages/AttackViewModel.cs
+++ b/MainCore/UI/ViewModels/Tabs/Villages/AttackViewModel.cs
@@ -34,9 +34,9 @@ namespace MainCore.UI.ViewModels.Tabs.Villages
 
             var (x, y, type, troops, executeAt) = AttackInput.Get();
             var plan = new AttackPlan { X = x, Y = y, Type = type, Troops = troops };
-            var task = new AttackTask.Task(AccountId, VillageId, villageName, plan)
+            var task = new AttackTask.Task(AccountId, VillageId, villageName, plan, executeAt)
             {
-                ExecuteAt = executeAt
+                ExecuteAt = executeAt.AddSeconds(-20) > DateTime.Now ? executeAt.AddSeconds(-20) : DateTime.Now
             };
             _taskManager.Add(task);
             await _dialogService.MessageBox.Handle(new MessageBoxData("Information", "Attack task scheduled"));

--- a/WPFUI/Views/Tabs/Villages/AttackTab.xaml
+++ b/WPFUI/Views/Tabs/Villages/AttackTab.xaml
@@ -7,6 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:uc="clr-namespace:WPFUI.Views.UserControls"
     xmlns:enums="clr-namespace:MainCore.Enums;assembly=MainCore"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     mc:Ignorable="d"
     d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
@@ -21,7 +22,8 @@
             <Label Content="Y" VerticalAlignment="Center" />
             <TextBox x:Name="YInput" Width="50" Margin="5,0" />
             <Label Content="Time" VerticalAlignment="Center" Margin="10,0,0,0" />
-            <TextBox x:Name="TimeInput" Width="150" Margin="5,0" />
+            <DatePicker x:Name="DateInput" Width="120" Margin="5,0" />
+            <materialDesign:TimePicker x:Name="TimeInput" Width="100" Margin="5,0" />
     <ComboBox x:Name="AttackType" Width="100" Margin="10,0" SelectedValuePath="Tag">
         <ComboBoxItem Content="Reinforce" Tag="{x:Static enums:AttackTypeEnums.Reinforcement}" />
         <ComboBoxItem Content="Raid" Tag="{x:Static enums:AttackTypeEnums.Raid}" />

--- a/WPFUI/Views/Tabs/Villages/AttackTab.xaml
+++ b/WPFUI/Views/Tabs/Villages/AttackTab.xaml
@@ -23,7 +23,7 @@
             <TextBox x:Name="YInput" Width="50" Margin="5,0" />
             <Label Content="Time" VerticalAlignment="Center" Margin="10,0,0,0" />
             <DatePicker x:Name="DateInput" Width="120" Margin="5,0" />
-            <materialDesign:TimePicker x:Name="TimeInput" Width="100" Margin="5,0" />
+            <materialDesign:TimePicker x:Name="TimeInput" Width="120" Margin="5,0" WithSeconds="True" />
     <ComboBox x:Name="AttackType" Width="100" Margin="10,0" SelectedValuePath="Tag">
         <ComboBoxItem Content="Reinforce" Tag="{x:Static enums:AttackTypeEnums.Reinforcement}" />
         <ComboBoxItem Content="Raid" Tag="{x:Static enums:AttackTypeEnums.Raid}" />

--- a/WPFUI/Views/Tabs/Villages/AttackTab.xaml.cs
+++ b/WPFUI/Views/Tabs/Villages/AttackTab.xaml.cs
@@ -29,10 +29,16 @@ namespace WPFUI.Views.Tabs.Villages
                         s => int.TryParse(s, out var value) ? value : 0)
                     .DisposeWith(d);
                 this.Bind(ViewModel,
-                        vm => vm.AttackInput.ExecuteAt,
-                        v => v.TimeInput.Text,
-                        dt => dt.ToString("yyyy-MM-dd HH:mm:ss"),
-                        s => DateTime.TryParse(s, out var value) ? value : DateTime.Now)
+                        vm => vm.AttackInput.ExecuteDate,
+                        v => v.DateInput.SelectedDate,
+                        d => (DateTime?)d,
+                        d => d ?? DateTime.Today)
+                    .DisposeWith(d);
+                this.Bind(ViewModel,
+                        vm => vm.AttackInput.ExecuteTime,
+                        v => v.TimeInput.SelectedTime,
+                        dt => (DateTime?)dt,
+                        dt => dt ?? DateTime.Now)
                     .DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.AttackInput.AttackType, v => v.AttackType.SelectedValue).DisposeWith(d);
 


### PR DESCRIPTION
## Summary
- improve attack scheduler input using `DatePicker` and `TimePicker`
- prepare attack 20 seconds before selected time and confirm exactly at time

## Testing
- `dotnet build TravBotSharp.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test TravBotSharp.sln` *(fails: libe_sqlite3 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852a68721ec832fac3e93afdd4d579d