### PR TITLE
Fix cross-thread access in attack tab

### DIFF
--- a/WPFUI/Views/Tabs/Villages/AttackTab.xaml.cs
+++ b/WPFUI/Views/Tabs/Villages/AttackTab.xaml.cs
@@ -72,6 +72,7 @@ namespace WPFUI.Views.Tabs.Villages
                 T11.ViewModel = troops[10];
 
                 this.WhenAnyValue(x => x.ViewModel.Tribe)
+                    .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(UpdateTroopNames)
                     .DisposeWith(d);
 


### PR DESCRIPTION
## Summary
- ensure AttackTab updates troop names on UI thread

## Testing
- `dotnet build` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6852cb023c78832f96462cf2e8d73f05