### PR TITLE
Fix upgrade button detection

### DIFF
--- a/MainCore.Test/Parsers/UpgradeParser.Test.cs
+++ b/MainCore.Test/Parsers/UpgradeParser.Test.cs
@@ -78,5 +78,23 @@ namespace MainCore.Test.Parsers
             var actual = MainCore.Parsers.UpgradeParser.GetUpgradingLevel(_html);
             actual.ShouldBe(10);
         }
+
+        [Fact]
+        public void GetNextLevel_NoButton()
+        {
+            _html.Load(CrannyEmpty);
+            var actual = MainCore.Parsers.UpgradeParser.GetNextLevel(_html, BuildingEnums.Cranny);
+            actual.ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData(MarketplaceConstructed, BuildingEnums.Marketplace, 2)]
+        [InlineData(CroplandConstructed, BuildingEnums.Cropland, 2)]
+        public void GetNextLevel_ShouldParse(string path, BuildingEnums building, int expected)
+        {
+            _html.Load(path);
+            var actual = MainCore.Parsers.UpgradeParser.GetNextLevel(_html, building);
+            actual.ShouldBe(expected);
+        }
     }
 }

--- a/MainCore.Test/Parsers/UpgradeParser.Test.cs
+++ b/MainCore.Test/Parsers/UpgradeParser.Test.cs
@@ -88,7 +88,7 @@ namespace MainCore.Test.Parsers
         }
 
         [Theory]
-        [InlineData(MarketplaceConstructed, BuildingEnums.Marketplace, 2)]
+        [InlineData(MarketplaceConstructed, BuildingEnums.Marketplace, 4)]
         [InlineData(CroplandConstructed, BuildingEnums.Cropland, 2)]
         public void GetNextLevel_ShouldParse(string path, BuildingEnums building, int expected)
         {

--- a/MainCore/Parsers/UpgradeParser.cs
+++ b/MainCore/Parsers/UpgradeParser.cs
@@ -103,6 +103,10 @@ namespace MainCore.Parsers
 
         public static int? GetNextLevel(HtmlDocument doc, BuildingEnums building)
         {
+            // Upgrade button is only available when the building can be upgraded
+            var upgradeButton = GetUpgradeButton(doc);
+            if (upgradeButton is null) return null;
+
             var resources = GetRequiredResource(doc, building);
             if (resources is null || resources.Count != 5) return null;
 


### PR DESCRIPTION
## Summary
- don't compute next level when upgrade button is absent
- test GetNextLevel in parser

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540972f108832faed102f270571ab7