### PR TITLE
Fix NPC granary check using current page

### DIFF
--- a/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/NpcResourceCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MainCore.Constraints;
+using MainCore.Parsers;
 
 namespace MainCore.Commands.Features.NpcResource
 {
@@ -32,13 +33,13 @@ namespace MainCore.Commands.Features.NpcResource
             if (currentVillage != villageId) return Skip.WrongVillage;
 
             var percentSetting = settingService.ByName(villageId, VillageSettingEnums.AutoNPCGranaryPercent);
-            var storage = context.Storages
-                .Where(x => x.VillageId == villageId.Value)
-                .Select(x => new { x.Crop, x.Granary })
-                .FirstOrDefault();
-            if (storage is not null && storage.Granary > 0)
+
+            // Check granary level from current page to avoid using stale DB data
+            var currentCrop = StorageParser.GetCrop(html);
+            var granaryCapacity = StorageParser.GetGranaryCapacity(html);
+            if (granaryCapacity > 0)
             {
-                var percent = storage.Crop * 100f / storage.Granary;
+                var percent = currentCrop * 100f / granaryCapacity;
                 if (percent < percentSetting) return Skip.GranaryNotReady;
             }
 


### PR DESCRIPTION
## Summary
- fix NPC dialog granary threshold check by reading crop and granary from the current page

## Testing
- `dotnet test -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854108c2bf8832fadb6dbbbb988d881