### PR TITLE
Preserve village tab selection

### DIFF
--- a/MainCore/Enums/VillageNormalTabType.cs
+++ b/MainCore/Enums/VillageNormalTabType.cs
@@ -1,0 +1,9 @@
+namespace MainCore.Enums
+{
+    public enum VillageNormalTabType
+    {
+        Build = 0,
+        Attack,
+        Settings
+    }
+}

--- a/MainCore/UI/Stores/VillageTabStore.cs
+++ b/MainCore/UI/Stores/VillageTabStore.cs
@@ -1,4 +1,5 @@
-﻿using MainCore.UI.ViewModels.Abstract;
+﻿using MainCore.Enums;
+using MainCore.UI.ViewModels.Abstract;
 using MainCore.UI.ViewModels.Tabs.Villages;
 
 namespace MainCore.UI.Stores
@@ -8,6 +9,7 @@ namespace MainCore.UI.Stores
     {
         private readonly bool[] _tabVisibility = new bool[2];
         private VillageTabType _currentTabType;
+        private VillageNormalTabType _currentNormalTab = VillageNormalTabType.Build;
 
         [Reactive]
         private bool _isNoVillageTabVisible = true;
@@ -28,6 +30,16 @@ namespace MainCore.UI.Stores
             _infoViewModel = infoViewModel;
             _villageSettingViewModel = villageSettingViewModel;
             _attackViewModel = attackViewModel;
+
+            _buildViewModel.WhenAnyValue(x => x.IsActive)
+                .Where(x => x)
+                .Subscribe(_ => _currentNormalTab = VillageNormalTabType.Build);
+            _attackViewModel.WhenAnyValue(x => x.IsActive)
+                .Where(x => x)
+                .Subscribe(_ => _currentNormalTab = VillageNormalTabType.Attack);
+            _villageSettingViewModel.WhenAnyValue(x => x.IsActive)
+                .Where(x => x)
+                .Subscribe(_ => _currentNormalTab = VillageNormalTabType.Settings);
         }
 
         public void SetTabType(VillageTabType tabType)
@@ -51,13 +63,19 @@ namespace MainCore.UI.Stores
                     break;
 
                 case VillageTabType.Normal:
-                    _buildViewModel.IsActive = true;
-                    _attackViewModel.IsActive = true;
+                    ActivateCurrentNormalTab();
                     break;
 
                 default:
                     break;
             }
+        }
+
+        private void ActivateCurrentNormalTab()
+        {
+            _buildViewModel.IsActive = _currentNormalTab == VillageNormalTabType.Build;
+            _attackViewModel.IsActive = _currentNormalTab == VillageNormalTabType.Attack;
+            _villageSettingViewModel.IsActive = _currentNormalTab == VillageNormalTabType.Settings;
         }
 
         public NoVillageViewModel NoVillageViewModel => _noVillageViewModel;

--- a/MainCore/UI/ViewModels/UserControls/ListBoxItemViewModel.cs
+++ b/MainCore/UI/ViewModels/UserControls/ListBoxItemViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using MainCore.UI.Models.Output;
 using MainCore.UI.ViewModels.Abstract;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace MainCore.UI.ViewModels.UserControls
 {
@@ -22,7 +23,7 @@ namespace MainCore.UI.ViewModels.UserControls
 
         public void Load(IEnumerable<ListBoxItem> items)
         {
-            var oldIndex = SelectedIndex;
+            var oldId = SelectedItemId;
             Items.Clear();
             foreach (var item in items)
             {
@@ -31,17 +32,14 @@ namespace MainCore.UI.ViewModels.UserControls
 
             if (Items.Count > 0)
             {
-                if (oldIndex == -1)
+                var matched = Items.FirstOrDefault(x => x.Id == oldId);
+                if (matched is not null)
                 {
-                    SelectedItem = Items[0];
-                }
-                else if (oldIndex < Items.Count)
-                {
-                    SelectedItem = Items[oldIndex];
+                    SelectedItem = matched;
                 }
                 else
                 {
-                    SelectedItem = Items[^1];
+                    SelectedItem = Items[0];
                 }
             }
             else


### PR DESCRIPTION
## Summary
- keep the current village and tab when list refreshes
- default to Build tab when switching to villages

## Testing
- `dotnet build TravBotSharp.sln -c Release` *(fails: `dotnet` not found)*
- `dotnet test TravBotSharp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546fb7329c832fb6c120b06fb5d637