### PR TITLE
Refresh building data before queue check

### DIFF
--- a/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
@@ -24,6 +24,9 @@ namespace MainCore.Commands.Features.UpgradeBuilding
         {
             var (accountId, villageId) = command;
 
+            var updateResult = await updateBuildingCommand.HandleAsync(new(accountId, villageId), cancellationToken);
+            if (updateResult.IsFailed) return Result.Fail<Response>(updateResult.Errors);
+
             var (_, isFailed, job, errors) = await getJobQuery.HandleAsync(new(accountId, villageId), cancellationToken);
             if (isFailed) return Result.Fail<Response>(errors);
 

--- a/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
+++ b/MainCore/Commands/Features/UpgradeBuilding/HandleJobCommand.cs
@@ -24,8 +24,8 @@ namespace MainCore.Commands.Features.UpgradeBuilding
         {
             var (accountId, villageId) = command;
 
-            var updateResult = await updateBuildingCommand.HandleAsync(new(accountId, villageId), cancellationToken);
-            if (updateResult.IsFailed) return Result.Fail<Response>(updateResult.Errors);
+            var initialUpdateResult = await updateBuildingCommand.HandleAsync(new(accountId, villageId), cancellationToken);
+            if (initialUpdateResult.IsFailed) return Result.Fail<Response>(initialUpdateResult.Errors);
 
             var (_, isFailed, job, errors) = await getJobQuery.HandleAsync(new(accountId, villageId), cancellationToken);
             if (isFailed) return Result.Fail<Response>(errors);


### PR DESCRIPTION
## Summary
- refresh building info before selecting the next upgrade job

## Testing
- `dotnet test --runtime win-x64 --no-build` *(fails: The argument /workspace/TravianBotSharp/MainCore.Test/bin/Debug/net8.0-windows/win-x64/MainCore.Test.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6854bd623280832f8ec04f3ad263f7c4