### PR TITLE
Revise troop training queue handling

### DIFF
--- a/MainCore/Commands/Features/TrainTroop/GetTrainQueueTimeCommand.cs
+++ b/MainCore/Commands/Features/TrainTroop/GetTrainQueueTimeCommand.cs
@@ -1,0 +1,50 @@
+using MainCore.Constraints;
+using MainCore.Errors.TrainTroop;
+using MainCore.Enums;
+using MainCore.Parsers;
+using MainCore.Services;
+using MainCore.Commands.Features.TrainTroop;
+
+namespace MainCore.Commands.Features.TrainTroop
+{
+    [Handler]
+    public static partial class GetTrainQueueTimeCommand
+    {
+        public sealed record Command(AccountId AccountId, VillageId VillageId, BuildingEnums Building) : IAccountVillageCommand;
+
+        private static async ValueTask<Result<TimeSpan>> HandleAsync(
+            Command command,
+            IChromeBrowser browser,
+            ToDorfCommand.Handler toDorfCommand,
+            UpdateBuildingCommand.Handler updateBuildingCommand,
+            ToBuildingCommand.Handler toBuildingCommand,
+            CancellationToken cancellationToken)
+        {
+            var (accountId, villageId, building) = command;
+
+            Result result;
+            result = await toDorfCommand.HandleAsync(new(accountId, 2), cancellationToken);
+            if (result.IsFailed) return Result.Fail(result.Errors);
+
+            var (_, isFailed, response, errors) = await updateBuildingCommand.HandleAsync(new(accountId, villageId), cancellationToken);
+            if (isFailed) return Result.Fail(errors);
+
+            var buildingLocation = response.Buildings
+                .Where(x => x.Type == building)
+                .Select(x => x.Location)
+                .FirstOrDefault();
+
+            if (buildingLocation == default)
+            {
+                return Result.Fail(MissingBuilding.Error(building).Errors);
+            }
+
+            result = await toBuildingCommand.HandleAsync(new(accountId, buildingLocation), cancellationToken);
+            if (result.IsFailed) return Result.Fail(result.Errors);
+
+            var html = browser.Html;
+            var queueTime = TrainTroopParser.GetQueueTime(html);
+            return queueTime == TimeSpan.Zero ? Result.Ok(TimeSpan.Zero) : Result.Ok(queueTime);
+        }
+    }
+}

--- a/MainCore/Commands/NextExecute/NextExecuteTrainTroopTaskCommand.cs
+++ b/MainCore/Commands/NextExecute/NextExecuteTrainTroopTaskCommand.cs
@@ -8,19 +8,13 @@ namespace MainCore.Commands.NextExecute
     {
         private static async ValueTask HandleAsync(
             TrainTroopTask.Task task,
+            TimeSpan queueTime,
             ILogger logger,
-            ISettingService settingService,
             CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            var seconds = settingService.ByName(
-                task.VillageId,
-                VillageSettingEnums.TrainTroopRepeatTimeMin,
-                VillageSettingEnums.TrainTroopRepeatTimeMax,
-                60
-            );
-
-            task.ExecuteAt = DateTime.Now.AddSeconds(seconds);
+            if (queueTime <= TimeSpan.Zero) queueTime = TimeSpan.FromMinutes(1);
+            task.ExecuteAt = DateTime.Now.Add(queueTime);
         }
     }
 }

--- a/MainCore/Parsers/TrainTroopParser.cs
+++ b/MainCore/Parsers/TrainTroopParser.cs
@@ -34,6 +34,20 @@
             return doc.GetElementbyId("s1");
         }
 
+        public static TimeSpan GetQueueTime(HtmlDocument doc)
+        {
+            var timers = doc.DocumentNode
+                .Descendants("span")
+                .Where(x => x.HasClass("timer"))
+                .Where(x => x.GetAttributeValue("counting", "") == "down")
+                .Select(x => x.GetAttributeValue("value", 0));
+
+            if (!timers.Any()) return TimeSpan.Zero;
+
+            var seconds = timers.Max();
+            return TimeSpan.FromSeconds(seconds);
+        }
+
         private static HtmlNode? GetNode(HtmlDocument doc, TroopEnums troop)
         {
             var nodes = doc.DocumentNode.Descendants("div")

--- a/MainCore/Tasks/TrainTroopTask.cs
+++ b/MainCore/Tasks/TrainTroopTask.cs
@@ -2,6 +2,8 @@
 using MainCore.Commands.NextExecute;
 using MainCore.Commands.UI.Misc;
 using MainCore.Errors.TrainTroop;
+using MainCore.Enums;
+using MainCore.Services;
 using MainCore.Tasks.Base;
 
 namespace MainCore.Tasks
@@ -21,35 +23,48 @@ namespace MainCore.Tasks
         private static async ValueTask<Result> HandleAsync(
             Task task,
             TrainTroopCommand.Handler trainTroopCommand,
+            GetTrainQueueTimeCommand.Handler getTrainQueueTimeCommand,
             GetTrainTroopBuildingQuery.Handler getTrainTroopBuildingQuery,
             SaveVillageSettingCommand.Handler saveVillageSettingCommand,
             NextExecuteTrainTroopTaskCommand.Handler nextExecuteTrainTroopTaskCommand,
+            ISettingService settingService,
             CancellationToken cancellationToken)
         {
             Result result;
+            var queueResult = await getTrainQueueTimeCommand.HandleAsync(new(task.AccountId, task.VillageId, BuildingEnums.Barracks), cancellationToken);
+            if (queueResult.IsFailed) return queueResult.ToResult();
+            var queueTime = queueResult.Value;
+
+            var minQueue = TimeSpan.FromMinutes(settingService.ByName(task.VillageId, VillageSettingEnums.TrainTroopRepeatTimeMin));
+
             var buildings = await getTrainTroopBuildingQuery.HandleAsync(new(task.VillageId), cancellationToken);
 
             var settings = new Dictionary<VillageSettingEnums, int>();
 
-            foreach (var building in buildings)
+            if (queueTime < minQueue)
             {
-                result = await trainTroopCommand.HandleAsync(new(task.AccountId, task.VillageId, building), cancellationToken);
-                if (!result.IsFailed) continue;
-
-                if (result.HasError<MissingBuilding>())
+                foreach (var building in buildings)
                 {
-                    settings.Add(TrainTroopCommand.BuildingSettings[building], 0);
-                    continue;
+                    result = await trainTroopCommand.HandleAsync(new(task.AccountId, task.VillageId, building), cancellationToken);
+                    if (!result.IsFailed) continue;
+
+                    if (result.HasError<MissingBuilding>())
+                    {
+                        settings.Add(TrainTroopCommand.BuildingSettings[building], 0);
+                        continue;
+                    }
+
+                    if (result.HasError<MissingResource>())
+                    {
+                        break;
+                    }
                 }
 
-                if (result.HasError<MissingResource>())
-                {
-                    break;
-                }
+                queueTime = minQueue;
             }
 
             await saveVillageSettingCommand.HandleAsync(new(task.AccountId, task.VillageId, settings), cancellationToken);
-            await nextExecuteTrainTroopTaskCommand.HandleAsync(task, cancellationToken);
+            await nextExecuteTrainTroopTaskCommand.HandleAsync(task, queueTime, cancellationToken);
             return Result.Ok();
         }
     }

--- a/MainCore/UI/Models/Input/VillageSettingInput.cs
+++ b/MainCore/UI/Models/Input/VillageSettingInput.cs
@@ -31,7 +31,7 @@ namespace MainCore.UI.Models.Input
         public TroopSelectorViewModel GreatStableTroop { get; } = new();
         public TroopSelectorViewModel WorkshopTroop { get; } = new();
 
-        public RangeInputViewModel TrainTroopRepeatTime { get; } = new();
+        public AmountInputViewModel TrainTroopQueueTime { get; } = new();
         public RangeInputViewModel BarrackAmount { get; } = new();
         public RangeInputViewModel StableAmount { get; } = new();
         public RangeInputViewModel GreatBarrackAmount { get; } = new();
@@ -70,9 +70,7 @@ namespace MainCore.UI.Models.Input
 
             TrainTroopEnable = settings.GetValueOrDefault(VillageSettingEnums.TrainTroopEnable) == 1;
             TrainWhenLowResource = settings.GetValueOrDefault(VillageSettingEnums.TrainWhenLowResource) == 1;
-            TrainTroopRepeatTime.Set(
-                settings.GetValueOrDefault(VillageSettingEnums.TrainTroopRepeatTimeMin),
-                settings.GetValueOrDefault(VillageSettingEnums.TrainTroopRepeatTimeMax));
+            TrainTroopQueueTime.Set(settings.GetValueOrDefault(VillageSettingEnums.TrainTroopRepeatTimeMin));
             var barrackTroop = (TroopEnums)settings.GetValueOrDefault(VillageSettingEnums.BarrackTroop);
             BarrackTroop.Set(barrackTroop, BuildingEnums.Barracks, tribe);
             BarrackAmount.Set(
@@ -128,7 +126,7 @@ namespace MainCore.UI.Models.Input
 
             var trainTroopEnable = TrainTroopEnable ? 1 : 0;
             var trainWhenLowResource = TrainWhenLowResource ? 1 : 0;
-            var (trainTroopRepeatTimeMin, trainTroopRepeatTimeMax) = TrainTroopRepeatTime.Get();
+            var trainTroopQueueTime = TrainTroopQueueTime.Get();
             var barrackTroop = (int)BarrackTroop.Get();
             var (barrackAmountMin, barrackAmountMax) = BarrackAmount.Get();
             var stableTroop = (int)StableTroop.Get();
@@ -160,8 +158,7 @@ namespace MainCore.UI.Models.Input
                 { VillageSettingEnums.Tribe, tribe },
                 { VillageSettingEnums.TrainTroopEnable, trainTroopEnable },
                 { VillageSettingEnums.TrainWhenLowResource, trainWhenLowResource },
-                { VillageSettingEnums.TrainTroopRepeatTimeMin, trainTroopRepeatTimeMin },
-                { VillageSettingEnums.TrainTroopRepeatTimeMax, trainTroopRepeatTimeMax },
+                { VillageSettingEnums.TrainTroopRepeatTimeMin, trainTroopQueueTime },
                 { VillageSettingEnums.BarrackTroop, barrackTroop },
                 { VillageSettingEnums.BarrackAmountMin, barrackAmountMin },
                 { VillageSettingEnums.BarrackAmountMax, barrackAmountMax },

--- a/MainCore/UI/Models/Validators/VillageSettingInputValidator.cs
+++ b/MainCore/UI/Models/Validators/VillageSettingInputValidator.cs
@@ -10,12 +10,9 @@ namespace MainCore.UI.Models.Validators
                 .NotEqual(TribeEnums.Any)
                 .WithMessage("Tribe should be specific");
 
-            RuleFor(x => x.TrainTroopRepeatTime.Min)
-                .LessThanOrEqualTo(x => x.TrainTroopRepeatTime.Max)
-                .WithMessage("Minimum next train troop ({PropertyValue}) should be less than maximum next train troop ({ComparisonValue})");
-            RuleFor(x => x.TrainTroopRepeatTime.Min)
+            RuleFor(x => x.TrainTroopQueueTime.Value)
                 .GreaterThanOrEqualTo(0)
-                .WithMessage("Minimum next train troop ({PropertyValue}) should be positive number");
+                .WithMessage("Min Troops Queue ({PropertyValue}) should be positive number");
 
             RuleFor(x => x.BarrackAmount.Min)
                 .LessThanOrEqualTo(x => x.BarrackAmount.Max)

--- a/WPFUI/Views/Tabs/Villages/VillageSettingTab.xaml
+++ b/WPFUI/Views/Tabs/Villages/VillageSettingTab.xaml
@@ -79,7 +79,7 @@
                     <StackPanel>
                         <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="Troop training settings" VerticalAlignment="Center" FontWeight="Bold" />
                         <CheckBox x:Name="TrainTroopEnable" Content="Enable train troop" />
-                        <uc:RangeInputUc x:Name="TrainTroopRepeatTime" Text="Next train troop execute after" Unit="mins" />
+                        <uc:AmountInputUc x:Name="TrainTroopQueueTime" Text="Min Troops Queue" Unit="mins" />
                         <CheckBox x:Name="TrainWhenLowResource" Content="Train maximum number if low on resource" />
                         <StackPanel Orientation="Horizontal">
                             <uc:TroopSelectorUc x:Name="BarrackTroop" Text="Train in barrack" />

--- a/WPFUI/Views/Tabs/Villages/VillageSettingTab.xaml.cs
+++ b/WPFUI/Views/Tabs/Villages/VillageSettingTab.xaml.cs
@@ -32,7 +32,7 @@ namespace WPFUI.Views.Tabs.Villages
 
                 this.Bind(ViewModel, vm => vm.VillageSettingInput.TrainTroopEnable, v => v.TrainTroopEnable.IsChecked).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.VillageSettingInput.TrainWhenLowResource, v => v.TrainWhenLowResource.IsChecked).DisposeWith(d);
-                this.OneWayBind(ViewModel, vm => vm.VillageSettingInput.TrainTroopRepeatTime, v => v.TrainTroopRepeatTime.ViewModel).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.VillageSettingInput.TrainTroopQueueTime, v => v.TrainTroopQueueTime.ViewModel).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageSettingInput.BarrackTroop, v => v.BarrackTroop.ViewModel).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageSettingInput.BarrackAmount, v => v.BarrackAmount.ViewModel).DisposeWith(d);
                 this.OneWayBind(ViewModel, vm => vm.VillageSettingInput.StableTroop, v => v.StableTroop.ViewModel).DisposeWith(d);


### PR DESCRIPTION
## Summary
- parse current barracks training queue duration
- add command to obtain queue time
- adjust TrainTroop task to maintain minimum queue
- update next execute scheduling to use queue time
- rename UI and setting bindings for minimum troop queue

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c59d2054832f9e200d6919f61a73